### PR TITLE
docs: add GitHub Copilot CLI to supported clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The Atlassian Rovo MCP Server supports several clients, including:
 
 * [OpenAI ChatGPT](https://platform.openai.com/docs/guides/tools-connectors-mcp)
 * [Claude](https://code.claude.com/docs/en/mcp)
+* [GitHub Copilot CLI](https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli)
 * [Google Gemini](https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/mcp-server.md)
 * [Amazon Quick Suite](https://docs.aws.amazon.com/quicksuite/latest/userguide/mcp-integration.html)
 


### PR DESCRIPTION
Adds GitHub Copilot CLI to the supported clients list in the README.

## Changes
- Added GitHub Copilot CLI with link to official documentation
- Placed alphabetically between Claude and Google Gemini

This is a minimal documentation update to help Copilot CLI users discover that the Atlassian MCP Server is compatible with their tool.
<!-- Rovo Dev code review status -->
---
<img src="https://i.imgur.com/MCm0FWH.png" alt="" height="12"> <strong>You don't have access to Rovo Dev Standard</strong>
Ask your organization admin to add you to Rovo Dev Standard.
[More about code review errors](https://support.atlassian.com/rovo/docs/troubleshoot-rovo-dev-code-reviews/)
<!-- /Rovo Dev code review status -->

