### PR TITLE
fix(claude-plugin): add marketplace.json for URL-sourced plugin discovery

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "atlassian",
+  "description": "Atlassian plugin marketplace for Claude Code",
+  "owner": {
+    "name": "Atlassian",
+    "email": "support@atlassian.com"
+  },
+  "plugins": [
+    {
+      "name": "atlassian",
+      "description": "Connect to Atlassian products including Jira and Confluence. Search and create issues, access documentation, manage sprints, and integrate your development workflow with Atlassian's collaboration tools.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Atlassian",
+        "email": "support@atlassian.com"
+      },
+      "source": "./",
+      "category": "productivity",
+      "homepage": "https://github.com/atlassian/atlassian-mcp-server"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `marketplace.json` to `.claude-plugin/` directory to enable proper plugin discovery when installed as a URL-sourced plugin in Claude Code

## Problem

When the Atlassian plugin is installed via the `claude-plugins-official` marketplace (which references this repo as an external URL source), the MCP server and skills are **not discovered** by Claude Code. The plugin appears as installed, but no Atlassian MCP tools or skills (triage-issue, generate-status-report, etc.) are available.

## Discovery

I had a `marketplace.json` file locally for testing and didn't think it would change behavior, but it did. With `marketplace.json` present, the MCP server and all 5 skills were properly discovered. Without it, nothing loaded. This led to investigating the difference between URL-sourced plugins that work and those that don't.

## Root Cause

Claude Code's plugin system handles URL-sourced plugins differently from local-path plugins. For URL-sourced plugins, it requires a `marketplace.json` file in `.claude-plugin/` to properly discover and activate:
- MCP servers (from `.mcp.json`)
- Skills (from `skills/` directory)

Without `marketplace.json`, the repo is cloned to cache but the `plugin.json` fields (`mcpServers`, `skills`) are not resolved.

## Evidence

All other working URL-sourced plugins in the Claude Code marketplace include `marketplace.json`:
- [superpowers](https://github.com/obra/superpowers) - 14 skills ✅
- [huggingface-skills](https://github.com/huggingface/skills) - 8 skills + MCP ✅  
- [sentry](https://github.com/getsentry/sentry-for-claude) ✅
- [vercel](https://github.com/vercel/vercel-deploy-claude-code-plugin) ✅
- [pinecone](https://github.com/pinecone-io/pinecone-claude-code-plugin) ✅
- [firecrawl](https://github.com/firecrawl/firecrawl-claude-plugin) ✅

Plugins **without** `marketplace.json` (figma, circleback, PostHog, coderabbit) also have the same discovery issue.

## Test plan

- [ ] Install the Atlassian plugin from the `claude-plugins-official` marketplace in Claude Code
- [ ] Verify the Atlassian MCP server tools are available
- [ ] Verify the 5 skills are discoverable (triage-issue, capture-tasks-from-meeting-notes, generate-status-report, search-company-knowledge, spec-to-backlog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)