### PR TITLE
Rename additional_fields to fields in skill docs

### DIFF
--- a/skills/spec-to-backlog/SKILL.md
+++ b/skills/spec-to-backlog/SKILL.md
@@ -431,9 +431,9 @@ https://yoursite.atlassian.net/browse/PROJ-123
 
 2. Ask user for values: "This project requires a 'Priority' field. What priority should I use? (e.g., High, Medium, Low)"
 
-3. Include in `additional_fields` when creating:
+3. Include in `fields` when creating:
    ```
-   additional_fields={
+   fields={
      "priority": {"name": "High"}
    }
    ```

--- a/skills/triage-issue/SKILL.md
+++ b/skills/triage-issue/SKILL.md
@@ -302,7 +302,7 @@ createJiraIssue(
   issueTypeName="Bug",
   summary="[Clear, specific summary - see below]",
   description="[Detailed description - see below]",
-  additional_fields={
+  fields={
     "priority": {"name": "Medium"}  # Adjust based on user input severity assessment
   }
 )
@@ -524,7 +524,7 @@ Please provide these values so I can create the issue.
 ```
 createJiraIssue(
   ...existing parameters...,
-  additional_fields={
+  fields={
     "priority": {"name": "High"},
     "customfield_10001": {"value": "Production"}
   }


### PR DESCRIPTION
Update parameter name to match the tool's new 'fields' parameter in:
- triage-issue/SKILL.md (2 occurrences)
- spec-to-backlog/SKILL.md (2 occurrences)