### PR TITLE
Revert "Rename additional_fields to fields in skill docs" (#127)

### DIFF
--- a/skills/spec-to-backlog/SKILL.md
+++ b/skills/spec-to-backlog/SKILL.md
@@ -431,9 +431,9 @@ https://yoursite.atlassian.net/browse/PROJ-123
 
 2. Ask user for values: "This project requires a 'Priority' field. What priority should I use? (e.g., High, Medium, Low)"
 
-3. Include in `fields` when creating:
+3. Include in `additional_fields` when creating:
    ```
-   fields={
+   additional_fields={
      "priority": {"name": "High"}
    }
    ```

--- a/skills/triage-issue/SKILL.md
+++ b/skills/triage-issue/SKILL.md
@@ -302,7 +302,7 @@ createJiraIssue(
   issueTypeName="Bug",
   summary="[Clear, specific summary - see below]",
   description="[Detailed description - see below]",
-  fields={
+  additional_fields={
     "priority": {"name": "Medium"}  # Adjust based on user input severity assessment
   }
 )
@@ -524,7 +524,7 @@ Please provide these values so I can create the issue.
 ```
 createJiraIssue(
   ...existing parameters...,
-  fields={
+  additional_fields={
     "priority": {"name": "High"},
     "customfield_10001": {"value": "Production"}
   }


### PR DESCRIPTION
Reverts #127 which was merged by mistake. Restores `additional_fields` parameter name in `triage-issue/SKILL.md` and `spec-to-backlog/SKILL.md`.



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

