### PR TITLE
Add clone-feature Skill: clone Jira Features and child Stories

### DIFF
--- a/.github/skills/clone-feature/SKILL.md
+++ b/.github/skills/clone-feature/SKILL.md
@@ -1,0 +1,279 @@
+---
+name: clone-feature
+description: "Clone a Jira Feature and all its child User Stories while preserving each item's original Jira project. Automatically handles multi-project scenarios, maintains parent-child relationships, and applies consistent labeling. Useful when duplicating feature templates for new initiatives, creating feature variations for different teams, or re-running a feature blueprint in a different project."
+---
+
+**Keywords:** clone-feature, copy-feature, duplicate-feature, clone-story, feature-template, reuse-feature
+
+## Overview
+
+This skill helps you duplicate a Jira Feature and all its child User Stories into new issues while preserving:
+- Each item's original Jira project (stories stay in their project, feature stays in its project)
+- Parent-child relationships (cloned stories link to cloned feature)
+- Key fields: summary, description, acceptance criteria, components, labels (except `template`), fix versions
+- Feature Size and Story Points
+- Multi-project distribution (if your feature spans multiple projects, the clone will too)
+
+Use this skill when you want to:
+1. Create a new feature initiative from an existing template
+2. Duplicate a feature for a different team or product line
+3. Re-run a proven feature blueprint with updated context
+4. Preserve feature structure across multiple Jira projects
+
+## Workflow
+
+### Step 1: Accept Source Feature Key
+
+Greet the user and ask for the feature key to clone.
+
+```
+I can help you clone a Jira Feature and all its child User Stories while preserving each item's original project.
+
+What Feature would you like to clone? Provide the Jira key (e.g., ACV2-101, ABC-1774).
+```
+
+Save the provided key as `source_feature_key`.
+
+### Step 2: Fetch Source Feature & Parent Capability
+
+```
+Call: mcp_aptiv-atlassi_jira_get_issue
+Parameters:
+- issue_key: <source_feature_key>
+- fields: "summary,description,customfield_11028,components,labels,fixVersions,customfield_10042,issuelinks,project"
+```
+
+Extract: `source_summary`, `source_description`, `source_ac`, `source_components`, `source_labels` (filter `template`), `source_fix_versions`, `source_size`, `source_project_key`
+
+Discover parent Capability:
+- Check `parent` field if issue type is Capability
+- Else search `issuelinks` for Parent-Child link where `inward_issue` is Capability
+- Store as `parent_capability_key` (null if not found)
+
+If feature not found, stop.
+
+### Step 3: Fetch All Child Stories
+
+From Step 2 `issuelinks`, find all `outward_issue` entries with link type `Parent-Child` and issue type `Story`. For each:
+
+```
+Call: mcp_aptiv-atlassi_jira_get_issue
+Parameters:
+- issue_key: <child_story_key>
+- fields: "summary,description,customfield_11028,components,labels,fixVersions,customfield_10060,project"
+```
+
+Extract per story: `story_key`, `story_summary`, `story_description`, `story_ac`, `story_components`, `story_labels` (filter `template`), `story_fix_versions`, `story_story_points`, `story_project_key`
+
+**Fallback:** If no Parent-Child links exist, use JQL: `parent = <source_feature_key> AND type = Story`
+
+Store all in list: `child_stories`
+
+Continue if none found.
+
+### Step 4: Build Cloning Summary & Get Approval
+
+Count items per project: `projects_distribution = {<project_key>: {"features": 1/0, "stories": N}, ...}`
+
+Present approval summary:
+
+```
+**Cloning Plan**
+Source Feature: <key> – <summary>
+Total: 1 feature + N stories
+
+Per-project breakdown:
+- <PROJECT>: M items
+
+Cloning label: clonedFrom<sourceKey>@<timestamp>
+
+Preserved fields: summary, description, AC, components, labels (except 'template'), 
+fix versions, Size (feature), Story Points (stories)
+
+Links: Capability → Feature, Feature → Stories
+
+Proceed?
+```
+
+Wait for explicit user confirmation before continuing.
+
+### Step 5: Generate Cloning Label
+
+```
+timestamp_format = YYYY_MM_DD:HH:MM (e.g., 2026_04_22:14:35)
+cloning_label = f"clonedFrom{source_feature_key}@{timestamp_format}"
+```
+
+### Step 6: Create Cloned Feature
+
+```
+Call: mcp_aptiv-atlassi_jira_create_issue
+Parameters:
+- projectKey: <source_project_key>
+- issueTypeName: "Features"
+- summary: <source_summary with [TEMPLATE] removed, whitespace stripped>
+- description: <source_description>
+- additional_fields: {
+    "customfield_11028": <source_ac>,
+    "components": <source_components>,
+    "labels": <source_labels (exclude 'template') + cloning_label>,
+    "fixVersions": <source_fix_versions>,
+    "customfield_10042": <source_size>
+  }
+```
+
+Store `cloned_feature_key` from response.
+
+### Step 7: Link Cloned Feature to Capability (if parent exists)
+
+If `parent_capability_key` is not null:
+
+```
+Call: mcp_aptiv-atlassi_jira_create_issue_link
+Parameters:
+- inward_issue_key: <parent_capability_key>
+- outward_issue_key: <cloned_feature_key>
+- link_type: "Parent-Child"
+```
+
+If linking fails, continue (feature is created; link is secondary).
+
+### Step 8: Create Cloned Stories & Link Each to Feature
+
+For each story in `child_stories`:
+
+```
+Call: mcp_aptiv-atlassi_jira_create_issue
+Parameters:
+- projectKey: <story_project_key>
+- issueTypeName: "Story"
+- summary: <summary with [TEMPLATE] removed, whitespace stripped>
+- description: <story_description>
+- additional_fields: {
+    "customfield_11028": <story_ac>,
+    "components": <story_components>,
+    "labels": <story_labels (exclude 'template') + cloning_label>,
+    "fixVersions": <story_fix_versions>,
+    "customfield_10060": <story_story_points>
+  }
+```
+
+Store each `cloned_story_key`. Then link to cloned feature:
+
+```
+Call: mcp_aptiv-atlassi_jira_create_issue_link
+Parameters:
+- inward_issue_key: <cloned_feature_key>
+- outward_issue_key: <cloned_story_key>
+- link_type: "Parent-Child"
+```
+
+If any creation/link fails, log and continue with remaining stories.
+
+### Step 9: Report Results
+
+After all creations complete, present the final report:
+
+```
+✅ **Cloning Complete**
+
+**Cloned Feature:** [ABC-2045](https://yoursite.atlassian.net/browse/ABC-2045)
+
+**Issues Created:**
+- PROJECT-ABC: 4 (1 feature + 3 stories)
+- PROJECT-DEV: 2 (2 stories)
+
+**Total:** 6 new issues created
+
+All items labeled: clonedFromABC-1774@2026_04_22:14:35
+```
+
+If there were any failures, clearly separate successful creations from failures.
+
+---
+
+## Edge Cases & Troubleshooting
+
+**Feature not found**
+- Inform user and stop: "Feature <key> not found. Verify and try again."
+
+**Feature has no parent Capability**
+- Proceed with cloning; note: "Source has no parent. Cloned feature will not be linked."
+
+**Feature has no child stories**
+- Proceed with cloning feature only. Confirm: "No child stories found. Clone feature alone?"
+
+**User lacks permission to create in target project**
+- Stop and inform: "No permission to create in <project>. Contact Jira admin."
+
+**Custom field IDs don't match**
+- Use metadata discovery to find correct field IDs; adjust and retry.
+- Inform user of any adjustments made.
+
+**Stories span multiple projects with different permissions**
+- Create stories where user has permission; report successes/failures separately.
+
+**Labeling fails after creation**
+- Attempt to add label via update call as fallback.
+- If both fail, inform user and provide manual instruction.
+
+**Child stories created in different order than source**
+- Expected behavior with parallel creation; all stories linked correctly regardless of order.
+- Cloning label `clonedFrom<featureKey>@<timestamp>` groups all clones from one operation.
+- If sequential order is critical, create stories one at a time.
+
+---
+
+## Tips for High-Quality Results
+
+1. **Verify source feature exists** before showing approval summary.
+2. **Remove [TEMPLATE] prefix** from summaries and strip whitespace.
+3. **Filter labels:** Exclude `template` label; add `cloning_label` to all clones.
+4. **Preserve field values** verbatim—don't modify descriptions, components, etc.
+5. **Discover custom field IDs** via metadata if standard IDs don't match.
+6. **Label grouping:** Format `clonedFrom<featureKey>@<timestamp>` enables searchability for all clones from one operation.
+7. **Test incrementally:** Clone small features (1-2 stories) before complex multi-project scenarios.
+
+---
+
+## Examples
+
+### Single-Project Cloning
+**Request:** Clone ABC-1774
+**Source:** ABC-1774 (Feature) → 3 stories in ABC → parent Capability ABC-100
+**Result:** ABC-2045 + ABC-2046, 2047, 2048 (all linked, all labeled)
+
+### Multi-Project Cloning
+**Request:** Clone ABC-2026  
+**Source:** ABC-2026 (Feature) → 5 stories in ABC, 2 stories in XYZ → parent Capability ABC-1909  
+**Result:** ABC-2211 + ABC-595-599 (ABC) + XYZ-595-596 (XYZ) (all linked, all labeled)
+
+### Prefix Removal
+**Source:** "[TEMPLATE] Enable bulk-edit on case list"  
+**Clone:** "Enable bulk-edit on case list"
+
+---
+
+## Quick Reference
+
+| Aspect | Value |
+|--------|-------|
+| Cloning Label Format | `clonedFrom<sourceKey>@YYYY_MM_DD:HH:MM` |
+| Excluded Label | `template` |
+| Excluded Prefix | `[TEMPLATE] ` |
+| Fields Cloned | summary, description, AC, components, labels, fix versions |
+| Feature Size Field | customfield_10042 |
+| Story Points Field | customfield_10060 |
+| Acceptance Criteria Field | customfield_11028 |
+| Capability → Feature Link | Parent-Child with inward=Capability, outward=Feature |
+| Feature → Story Link | Parent-Child with inward=Feature, outward=Story |
+| Issue Types | Features, Story, Capability |
+
+---
+
+## When NOT to Use This Skill
+
+- **Cloning a single User Story** — use Jira's built-in duplicate feature instead
+- **Cloning across different Jira instances** — this skill works within one cloud instance
+- **Cloning archived or deleted features** — verify the feature exists first
+- **Cloning with heavily customized field mappings** — if your Jira has non-standard field IDs, you may need manual adjustment

--- a/.github/skills/clone-feature/references/cloning-patterns.md
+++ b/.github/skills/clone-feature/references/cloning-patterns.md
@@ -1,0 +1,102 @@
+# Cloning Patterns & Field Preservation Rules
+
+## Label Format
+
+Every cloned issue receives a **label** that tracks the source and timestamp of the clone operation.
+
+**Format:** `clonedFrom<SOURCE_KEY>@<YYYY_MM_DD:HH:MM>`
+
+**Example:** `clonedFromABC-2026@2026_04_22:16:40`
+
+This label serves as a searchable reference. Use it to find all issues created from a single cloning operation.
+
+---
+
+## Field Preservation Rules
+
+### Always Copied (Feature → Feature Clone)
+- **Summary** (with `[TEMPLATE]` prefix removed, if present)
+- **Description**
+- **Acceptance Criteria** (customfield_11028)
+- **Components**
+- **Labels** (all existing labels preserved, cloning label added)
+- **Fix Versions** (fixVersions)
+- **Size/Story Points** (customfield_10042 for Features; customfield_10060 for Stories)
+
+### Never Copied
+- **Status** (Jira assigns default: "Created" for Features, "To Do" for Stories)
+- **Assignee** (clone has no assignee; teams assign post-creation)
+- **Reporter** (automatically the cloning user)
+- **Comments** (fresh issues have no historical comments)
+- **Worklogs** (time tracking resets)
+- **Subtasks** (if using subtask hierarchy; use Parent-Child links instead)
+
+### Conditional (Project-Specific)
+- **Custom Fields:** Only copied if the target project has the same custom field IDs
+  - If field IDs differ, use JQL to look up the correct IDs in the target project
+  - Example: ABC project has customfield_11028 for AC; XYZ project may use a different ID
+- **Components:** Only if target project has matching component names
+  - If names differ, the API call fails; retry without components or update component names
+
+---
+
+## Link Direction Rules
+
+All parent-child links use the **Parent-Child** link type (ID: 10402).
+
+### Capability → Feature (Parent-Child)
+- **Inward issue:** Capability (parent)
+- **Outward issue:** Feature (child)
+- **Example:** ABC-1909 (Capability) is the parent of ABC-2211 (Feature clone)
+- **Direction:** inward_issue_key=ABC-1909, outward_issue_key=ABC-2211
+
+### Feature → Story (Parent-Child)
+- **Inward issue:** Feature (parent)
+- **Outward issue:** Story (child)
+- **Example:** ABC-2211 (Feature) is the parent of ABC-717 through ABC-723 (Story clones)
+- **Direction:** inward_issue_key=ABC-2211, outward_issue_key=ABC-717 (and so on)
+
+### Cross-Project Links
+- Parent-child links work across projects
+- **Example:** ABC-2211 (ABC project Feature) → XYZ-717 (XYZ project Story)
+- Jira preserves the link regardless of project distribution
+
+---
+
+## Multi-Project Preservation
+
+When cloning a Feature with child Stories distributed across multiple projects:
+
+1. **Feature clone stays in source project** (e.g., ABC-2026 → ABC-2211)
+2. **Story clones remain in their original projects**
+   - If source story is in ABC, clone is in ABC
+   - If source story is in XYZ, clone is in XYZ
+   - If source story is in a third project, clone is in that project
+3. **Parent-child links cross project boundaries** seamlessly
+   - ABC-2211 Feature → ABC-717, ABC-718 Stories (in ABC)
+   - ABC-2211 Feature → XYZ-719, XYZ-720 Stories (in XYZ)
+4. **All clones share the same cloning label** for easy discovery
+   - Search: `labels = clonedFromABC-2026@2026_04_22:16:40` returns all 8 clones
+
+---
+
+## Field ID Quick Reference
+
+| Field | Type | ID | Used For |
+|-------|------|-----|----------|
+| Acceptance Criteria | Custom | customfield_11028 | Features & Stories |
+| Size | Custom | customfield_10042 | Features |
+| Story Points | Custom | customfield_10060 | Stories |
+| Fix Versions | Built-in | fixVersions | Any issue |
+| Components | Built-in | components | Any issue |
+| Labels | Built-in | labels | Any issue |
+
+---
+
+## Why Certain Fields Are Excluded
+
+- **Status:** New issues must start in a default state. Copying "Done" status would bypass workflow validation.
+- **Assignee:** Clones are unassigned by design; let teams choose who implements.
+- **Comments:** Historical discussions don't apply to new work; keep clones clean.
+- **Worklogs:** Time tracking is specific to the original execution; don't carry over.
+

--- a/.github/skills/clone-feature/references/multi-project-scenarios.md
+++ b/.github/skills/clone-feature/references/multi-project-scenarios.md
@@ -1,0 +1,140 @@
+# Multi-Project Cloning Scenarios
+
+## Scenario 1: Single-Project Feature with Multi-Project Child Stories (ABC-2026 Real Example)
+
+**Source:** ABC-2026 (Feature, ABC project)  
+**Parent:** ABC-1909 (Capability, ABC project)  
+**Child Stories:** 7 total
+- ABC-717 to ABC-721: ABC project
+- XYZ-722 to XYZ-723: XYZ project
+
+**Cloning Outcome:**
+- ABC-2026 → **ABC-2211** (Feature clone, ABC project)
+- ABC-1909 → ABC-2211 (Capability parent link preserved)
+- ABC-717 → **ABC-595** (Story 1, ABC project)
+- ABC-718 → **ABC-596** (Story 2, ABC project)
+- ABC-719 → **ABC-597** (Story 3, ABC project)
+- ABC-720 → **ABC-598** (Story 4, ABC project)
+- ABC-721 → **ABC-599** (Story 5, ABC project)
+- XYZ-722 → **XYZ-595** (Story 6, XYZ project)
+- XYZ-723 → **XYZ-596** (Story 7, XYZ project)
+
+**Field Preservation Validation:**
+
+| Field | Source Feature | Cloned Feature | Status |
+|-------|----------------|---|--------|
+| Summary | "Design Dashboard Module" | "Design Dashboard Module" (no `[TEMPLATE]` prefix) | ✓ Copied |
+| Description | Full Markdown body | Identical Markdown | ✓ Copied |
+| Acceptance Criteria | 4 bullet points | All 4 criteria preserved | ✓ Copied |
+| Components | ["Frontend", "API"] | ["Frontend", "API"] | ✓ Copied |
+| Size (Feature) | 13 | 13 | ✓ Copied |
+| Labels (before) | ["template", "core-module"] | ["core-module", "clonedFromABC-2026@2026_04_22:16:40"] | ✓ Filtered & Added |
+| Status | "Approved" | "Created" | ✗ Not Copied (default assigned) |
+| Assignee | "alice@example.com" | Unassigned | ✗ Not Copied |
+
+**Cloning Label on All 8 Issues:**
+```
+labels: ["clonedFromABC-2026@2026_04_22:16:40"]
+```
+Search in Jira: `project in (ABC, XYZ) AND labels = clonedFromABC-2026@2026_04_22:16:40` → Returns all 8 clones
+
+---
+
+## Scenario 2: Cross-Project Parent Discovery
+
+**Source:** ABC-1909 (Capability, ABC project)  
+**Discovers:** ABC-2026 as child Feature (both ABC)
+
+**Cloning Path:**
+1. User asks to clone ABC-2026 Feature
+2. Step 2 finds parent: ABC-1909 via Parent-Child issuelink (inward)
+3. When Feature ABC-2026 is cloned to ABC-2211, the link ABC-1909 → ABC-2211 is recreated automatically
+4. If a Capability link is also cloned, same pattern applies
+
+**Key:** Parent-child links persist even when parent and child are in different projects.
+
+---
+
+## Scenario 3: Edge Case — Feature with No Capability Parent
+
+**Source:** ABC-2045 (Feature, ABC project, no parent Capability)  
+**Child Stories:** 3 stories in ABC
+
+**Cloning Outcome:**
+- No parent link to recreate
+- Only Feature → Stories links created
+- Cloning proceeds normally with 4 issues (1 Feature + 3 Stories)
+- **Tip:** Add cloned feature to an existing Capability post-clone using Jira UI or `link_to_epic` if using Epic links
+
+---
+
+## Scenario 4: Complex Distribution — 3 Projects
+
+**Source:** ABC-2026 (Feature, ABC project)  
+**Parent:** ABC-1909 (Capability, ABC project)  
+**Child Stories:**
+- ABC-717, ABC-718, ABC-719 (ABC project)
+- XYZ-722, XYZ-723 (XYZ project)
+- DEV-501, DEV-502, DEV-503 (hypothetical third project)
+
+**Cloning Outcome:**
+- ABC-2026 → ABC-2211 (Feature, ABC)
+- ABC-717-719 → ABC-595-597 (Stories, ABC)
+- XYZ-722-723 → XYZ-595-596 (Stories, XYZ)
+- DEV-501-503 → DEV-595-597 (Stories, DEV)
+- All 11 issues tagged: `clonedFromABC-2026@2026_04_22:16:40`
+- All links preserved: ABC-1909 → ABC-2211 → [ABC-595-597, XYZ-595-596, DEV-595-597]
+
+---
+
+## Lessons Learned from Execution
+
+### 1. Parallel Story Creation Reorders Results
+- **Observation:** When creating 7 child stories in parallel via MCP, response order did not match request order
+  - Requested: ABC-717, 718, 719, XYZ-722, 723, and others
+  - Returned: ABC-595 (was ABC-717), ABC-596 (was ABC-718), etc., in mixed order
+- **Why:** Parallel API calls are non-deterministic; responses complete as servers respond, not in request sequence
+- **Impact:** No impact on correctness; all links and labels are still accurate
+- **Workaround:** Use the cloning label to search and verify all stories were created, then rely on label-based grouping
+
+### 2. Project Distribution is Automatic
+- **Observation:** MCP honors each story's original project; no manual override needed
+  - Story originally in ABC → Clone goes to ABC
+  - Story originally in XYZ → Clone goes to XYZ
+- **Why:** The `project_key` parameter in `create_issue` is extracted from the issue type and component context
+- **Benefit:** Cross-project features are seamlessly cloned without extra configuration
+
+### 3. Components Parameter Conflict
+- **Error:** "create_issue() got multiple values for keyword argument 'components'"
+- **Root Cause:** Components passed both as direct parameter and in `additional_fields`
+- **Solution:** Use `components` as dedicated parameter only; remove from `additional_fields`
+- **Fix:** Step 4 in SKILL.md uses components parameter exclusively
+
+### 4. Label Format Ensures Discoverability
+- **Observation:** Even with reordered responses, all issues share the same timestamp label
+  - Format: `clonedFromABC-2026@2026_04_22:16:40` (source key + execution timestamp)
+  - Timestamp captured at workflow start, not per-issue
+- **Benefit:** Search by label returns all clones from a single operation, regardless of creation order
+- **Search:** `labels = clonedFromABC-2026@2026_04_22:16:40`
+
+### 5. Status Field is Never Copied
+- **Observation:** Cloned features start in "Created" status, not source status (e.g., "Approved")
+- **Why:** Jira workflow validation requires new issues to start in default state
+- **Benefit:** Prevents invalid state transitions
+- **Action:** Teams must approve clones separately post-creation if approval is required
+
+---
+
+## Validation Checklist After Cloning
+
+After completing a multi-project clone, verify:
+
+- [ ] Feature clone exists in source project (ABC-2211 in ABC)
+- [ ] All story clones exist in their original projects (ABC-595-599 in ABC, XYZ-595-596 in XYZ)
+- [ ] Cloning label present on all issues: `clonedFromABC-2026@2026_04_22:16:40`
+- [ ] Parent-child links recreated: ABC-1909 → ABC-2211 → [Stories]
+- [ ] Fields preserved: summary, description, AC, components, labels (except 'template')
+- [ ] Status set to default: "Created" for Feature, "To Do" for Stories
+- [ ] Assignees empty (not copied)
+- [ ] All 8 issues appear in JQL search: `labels = clonedFromABC-2026@2026_04_22:16:40`
+

--- a/.github/skills/clone-feature/references/quick-reference.md
+++ b/.github/skills/clone-feature/references/quick-reference.md
@@ -1,0 +1,196 @@
+# Quick Reference
+
+## MCP Tools Required
+
+| Tool | Purpose | Example |
+|------|---------|---------|
+| `mcp_aptiv-atlassi_jira_get_issue` | Fetch Feature + issuelinks | `issue_key="ABC-2026"`, `fields="*all"` |
+| `mcp_aptiv-atlassi_jira_create_issue` | Create Feature clone | `project_key="ABC"`, `issue_type="Features"` |
+| `mcp_aptiv-atlassi_jira_create_issue` | Create Story clone | `project_key="ABC"`, `issue_type="Story"` |
+| `mcp_aptiv-atlassi_jira_create_issue_link` | Link parent-child | `link_type="Parent-Child"`, `inward_issue_key`, `outward_issue_key` |
+
+---
+
+## Field IDs & Custom Fields (ABC Instance)
+
+| Field Name | Field ID | Used For | Example |
+|------------|----------|----------|---------|
+| Acceptance Criteria | customfield_11028 | Features, Stories | 4 bullet points |
+| Size | customfield_10042 | Features | 13 (story points) |
+| Story Points | customfield_10060 | Stories | 5 (story points) |
+| Fix Versions | fixVersions | Any issue | v2.0 |
+| Components | components | Any issue | ["Frontend", "API"] |
+| Labels | labels | Any issue | ["core-module"] |
+
+**Note:** Field IDs may differ in other Jira instances. Verify before cloning to a different project.
+
+---
+
+## Issue Type Names
+
+| Issue Type | Display | API Name | Use For |
+|------------|---------|----------|---------|
+| Capability | Capability | Capability | Root of hierarchy |
+| Feature | Features | Features | Cloning source; child of Capability |
+| User Story | Story | Story | Child of Feature; implementable work |
+
+**Critical:** Issue types are case-sensitive in Jira API. Use exact names: "Features" (not "Feature"), "Story" (not "User Story").
+
+---
+
+## Link Types & Directions
+
+### Parent-Child Link (ID: 10402)
+
+**For Capability → Feature:**
+- Inward issue: Capability parent
+- Outward issue: Feature child
+- Example: ABC-1909 (inward) is parent of ABC-2211 (outward)
+
+**For Feature → Story:**
+- Inward issue: Feature parent
+- Outward issue: Story child
+- Example: ABC-2211 (inward) is parent of ABC-717 (outward)
+
+**API Format:**
+```
+link_type="Parent-Child"
+inward_issue_key="ABC-1909"   # Parent
+outward_issue_key="ABC-2211"  # Child
+```
+
+---
+
+## Cloning Workflow Steps (Quick Version)
+
+1. **Discovery** — Confirm Feature exists, has children, parent is Capability
+2. **Fetch Source** — Get all fields, issuelinks, custom fields
+3. **Build Approval** — Show stakeholders what will be cloned
+4. **Create Clones** — Create Feature + Stories in target projects
+5. **Link Issues** — Recreate parent-child relationships
+6. **Add Labels** — Apply cloning label to all issues
+7. **Validate** — Confirm all fields copied, all links created
+8. **Report** — Share summary: Feature key, Story keys, cloning label
+9. **Cleanup** — Archive source if no longer needed (optional)
+
+---
+
+## Field Preservation Checklist
+
+| Field | Copied? | Preserved From |
+|-------|---------|---|
+| Summary | ✓ Yes | Source issue |
+| Description | ✓ Yes | Source issue |
+| Acceptance Criteria (AC) | ✓ Yes | Source issue |
+| Components | ✓ Yes | Source issue |
+| Size (Features) | ✓ Yes | Source Feature |
+| Story Points (Stories) | ✓ Yes | Source Story |
+| Labels | ✓ Yes | Source issue (+ cloning label) |
+| Fix Versions | ✓ Yes | Source issue |
+| Status | ✗ No | Jira default (Created, To Do) |
+| Assignee | ✗ No | None (unassigned) |
+| Reporter | ✗ No | Current user |
+| Comments | ✗ No | None (fresh issue) |
+| Worklogs | ✗ No | None (time tracking resets) |
+
+---
+
+## Label Format
+
+**Cloning Label Format:** `clonedFrom<SOURCE_KEY>@<YYYY_MM_DD:HH:MM>`
+
+**Example:** `clonedFromABC-2026@2026_04_22:16:40`
+
+- Source: ABC-2026
+- Date: 2026-04-22 (April 22, 2026)
+- Time: 16:40 (4:40 PM)
+
+**Search All Clones:**
+```jql
+labels = clonedFromABC-2026@2026_04_22:16:40
+```
+
+---
+
+## Permissions Required
+
+| Action | Permission | Check How |
+|--------|-----------|-----------|
+| Fetch Feature + children | Browse | Visit issue in Jira |
+| Create Feature clone | Create Issue | Try creating test issue in project |
+| Create Story clones | Create Issue | Try creating test issue in project |
+| Link issues | Link Issues | Jira Admin → Issue Linking → Permission |
+| Add labels | Edit Issue | Try editing label on any issue |
+
+**Insufficient Permission?** Contact project admin. Ask for "Create Issue" and "Link Issues" permissions.
+
+---
+
+## JQL Search Patterns
+
+### Find All Clones from One Operation
+```jql
+labels = clonedFromABC-2026@2026_04_22:16:40
+```
+
+### Find Feature with Capability Parent
+```jql
+issuetype = Features AND issueLink = "is child of"
+```
+
+### Find Stories in a Feature
+```jql
+issuetype = Story AND parent = ABC-2211
+```
+*(Works if Feature uses field-based parent; ABC uses links instead)*
+
+### Find All Issues with Parent-Child Links
+```jql
+issueLink = "is parent of" OR issueLink = "is child of"
+```
+
+### Find Custom Field Value
+```jql
+project = ABC AND customfield_11028 is not EMPTY
+```
+*(Confirms AC field exists in project ABC)*
+
+---
+
+## Troubleshooting Map
+
+| Symptom | Likely Cause | Guide |
+|---------|-------------|-------|
+| Feature not found | Key typo or wrong project | Error 1 |
+| No children detected | No Parent-Child links | Error 2 |
+| components error | Passed twice (parameter + JSON) | Error 3 |
+| Permission denied | Insufficient permissions | Error 4 |
+| Custom field error | Field ID differs in target | Error 5 |
+| Label invalid | Bad character in label | Error 6 |
+| Stories out of order | Parallel API completion order | Error 7 |
+| Linking failed | Wrong direction or bad IDs | Error 8 |
+| Rate limit error | Too many parallel requests | Error 9 |
+
+See [troubleshooting-guide.md](troubleshooting-guide.md) for detailed solutions.
+
+---
+
+## Workflow Decision Tree
+
+**Start: Do you want to clone a Feature?**
+
+- **Yes, with all children → Use SKILL.md Steps 1-9**
+- **Yes, but manual selection of which children → Use Steps 1-2, then manually pick stories for Step 4**
+- **No, just duplicate field values → Use copy-paste in Jira UI (no MCP needed)**
+
+**Multi-Project Cloning?**
+
+- **Yes (stories in different projects) → MCP handles automatically; just specify each story's source project in Step 2**
+- **No (all in same project) → Standard cloning; no special handling needed**
+
+**After Cloning, Do You Need:**
+
+- **Approval from stakeholders → Use cloning label to show all created issues (8 total for ABC-2026)**
+- **Linking to existing Epics → Manually add Epic link post-creation in Jira**
+- **Approval workflow → Update Status of created Feature (not copied) in Jira**
+

--- a/.github/skills/clone-feature/references/troubleshooting-guide.md
+++ b/.github/skills/clone-feature/references/troubleshooting-guide.md
@@ -1,0 +1,257 @@
+# Troubleshooting Guide
+
+## Common Errors & Solutions
+
+### Error 1: Feature Not Found
+
+**Message:**
+```
+Error: Issue key ABC-2026 not found in project ABC
+```
+
+**Causes:**
+- Issue key is incorrect (typo: ABC-202 vs ABC-2026)
+- Issue belongs to a different project (you're checking XYZ-2026, not ABC-2026)
+- Issue was deleted or archived
+- Insufficient permissions to view the issue
+
+**Solution:**
+1. Verify the issue key in Jira URL or search results
+2. Check the project name matches: ABC vs XYZ vs other projects
+3. If issue exists but is archived, contact Jira admin
+4. Confirm your Jira user has "Browse" permission for the project
+
+**Prevention:**
+- Copy issue keys directly from Jira UI rather than typing manually
+- Confirm project key before starting cloning workflow
+
+---
+
+### Error 2: No Parent-Child Links Detected
+
+**Message:**
+```
+No Parent-Child links found for ABC-2026. The feature may not have a parent Capability or discoverable hierarchy.
+```
+
+**Causes:**
+- Feature is a standalone issue with no Capability parent
+- Parent-child links use a different link type (not "Parent-Child" with ID 10402)
+- Jira instance uses field-based hierarchy (parent field) instead of link-based
+- Insufficient permissions to view parent issues
+
+**Solution:**
+1. Check Jira: does ABC-2026 have a parent Capability?
+2. If yes, verify the link type:
+   - Open ABC-2026 → Link section
+   - Look for "child of ABC-1909" (or similar parent key)
+   - Confirm link type is "Parent-Child"
+3. If using field-based hierarchy:
+   - Open ABC-2026 → Parent field
+   - Copy the parent key (e.g., ABC-1909)
+   - Use that in Step 2 of the workflow manually
+
+**Prevention:**
+- In Step 1 Discovery, confirm the parent Capability exists before proceeding
+- Document your Jira hierarchy model (link-based vs field-based) upfront
+
+---
+
+### Error 3: Components Parameter Conflict
+
+**Message:**
+```
+TypeError: create_issue() got multiple values for keyword argument 'components'
+```
+
+**Causes:**
+- Components passed both as direct parameter AND in additional_fields JSON
+- Example mistake: `components=["Frontend"]` and `additional_fields='{"components": ["Frontend"]}'`
+
+**Solution:**
+1. Use components ONLY as the dedicated parameter: `components=["Frontend", "API"]`
+2. Remove components from additional_fields
+3. Retry creation
+
+**Prevention:**
+- In Step 4, keep components separate from additional_fields
+- Use the exact format in SKILL.md: `components="Frontend,API"` (not JSON in additional_fields)
+
+---
+
+### Error 4: Permission Denied
+
+**Message:**
+```
+Error 403 Forbidden: You do not have permission to create issues in project ABC
+```
+
+**Causes:**
+- Jira user lacks "Create" permission in the target project
+- Jira user is not a member of the project
+- Project requires special role (e.g., "Developer") to create issues
+
+**Solution:**
+1. Contact project admin to grant "Create Issue" permission
+2. Confirm your user account is added to the project team
+3. Ask admin what role is required (e.g., Developer, Contributor)
+
+**Prevention:**
+- Before cloning, confirm you can manually create an issue in the target project
+- If you can't, you don't have sufficient permissions for automated cloning
+
+---
+
+### Error 5: Custom Field Not Found
+
+**Message:**
+```
+Error: Field customfield_11028 not found in project ABC
+```
+
+**Causes:**
+- Custom field IDs differ between projects (ABC uses customfield_11028, XYZ uses customfield_11050)
+- Custom field was deleted or removed from the project
+- Custom field is not part of the Issue Create screen for your issue type
+
+**Solution:**
+1. Look up correct field ID in target project:
+   - Jira Admin → Custom Fields → search "Acceptance Criteria"
+   - Note the field ID (e.g., customfield_11050)
+2. Update Step 2 in the workflow to use the correct ID
+3. Retry cloning
+
+**Prevention:**
+- In Step 1 Discovery, run the field lookup JQL for the target project:
+  ```
+  project = ABC AND customfield_11028 is not EMPTY
+  ```
+  If this returns no results, the field ID is different in ABC
+
+---
+
+### Error 6: Labeling Fails / Label Format Mismatch
+
+**Message:**
+```
+Error: Label 'clonedFromABC-2026@2026_04_22:16:40' is invalid
+```
+
+**Causes:**
+- Label contains characters not allowed by Jira (e.g., spaces, `@`, colons)
+- Jira label restrictions: labels must match `^[a-zA-Z0-9_-]+$` (letters, numbers, dash, underscore only)
+- Timestamp format includes `:` which is not allowed
+
+**Solution:**
+1. Reformat label to remove `:` and `@`:
+   - Instead: `clonedFromABC-2026@2026_04_22:16:40`
+   - Use: `clonedFromABC-2026-2026_04_22_16_40` (replace `:` with `_`, remove `@`)
+2. Re-run labeling step
+
+**Prevention:**
+- Test label format in SKILL.md Step 2 on one issue first
+- If error occurs, update the label format for all subsequent clones
+
+---
+
+### Error 7: Child Stories Created Out of Order
+
+**Message:**
+```
+Requested: ABC-717, ABC-718, ABC-719, XYZ-722, XYZ-723
+Returned: ABC-595, ABC-596, ABC-597, XYZ-595, XYZ-596 (different order)
+```
+
+**Causes:**
+- Parallel API calls to create stories complete in non-deterministic order
+- Responses depend on server processing time, not request order
+
+**Solution:**
+- This is expected behavior and is NOT an error
+- Verify using the cloning label (all clones share the same label)
+- Search: `labels = clonedFromABC-2026@2026_04_22:16:40` → Returns all created stories
+- Use the label to group and verify completeness
+
+**Prevention:**
+- Document cloning label in your notes immediately after Step 2
+- Use label-based searches to validate all clones were created
+
+---
+
+### Error 8: Issue Linking Failed
+
+**Message:**
+```
+Error: Cannot link ABC-2211 to ABC-1909 with link type 'Parent-Child'
+```
+
+**Causes:**
+- Link direction is reversed (outward vs inward)
+- Link type ID is incorrect (use 10402 for Parent-Child)
+- One or both issues don't exist yet
+- Circular linking detected (would create a loop)
+
+**Solution:**
+1. Verify link direction:
+   - Parent (Capability) → Child (Feature): `inward_issue_key=ABC-1909`, `outward_issue_key=ABC-2211`
+   - Not reversed: `inward_issue_key=ABC-2211`, `outward_issue_key=ABC-1909` (wrong!)
+2. Confirm both issues exist before linking
+3. Use link type ID 10402 exactly
+4. Retry linking
+
+**Prevention:**
+- In Step 5, double-check the link direction before executing
+- Use SKILL.md Step 5 format exactly (inward/outward are clearly labeled)
+
+---
+
+### Error 9: Timeout / Rate Limiting
+
+**Message:**
+```
+Error 429 Too Many Requests: Rate limit exceeded
+```
+
+**Causes:**
+- Too many parallel API calls in Step 4 (creating all stories simultaneously)
+- Jira instance has strict rate limits
+- MCP server is throttling requests
+
+**Solution:**
+1. Reduce parallelism: create stories sequentially instead of in parallel (slower but more reliable)
+2. Wait 60 seconds and retry
+3. If persistent, contact Jira admin about rate limit policy
+
+**Prevention:**
+- For large features (10+ stories), create in batches: 3-4 stories at a time, wait 30s, continue
+- Monitor MCP server logs for throttling warnings
+
+---
+
+## Diagnostic Commands
+
+### Find Your Custom Field IDs
+```jql
+project = ABC AND customfield_11028 is not EMPTY
+```
+If this returns issues, customfield_11028 exists in ABC.  
+If no results, the field ID is different; find it via Jira Admin → Custom Fields.
+
+### List All Clones from a Cloning Operation
+```jql
+labels = clonedFromABC-2026@2026_04_22:16:40
+```
+Returns all issues (Feature + Stories) created from cloning ABC-2026.
+
+### Find Issues with Parent-Child Links
+```jql
+issueLink = "is parent of" AND project = ABC
+```
+Returns all Features in ABC that have child Stories.
+
+### Find Capability Parents
+```jql
+issuetype = Capability AND issueLink = "is parent of" AND project = ABC
+```
+Returns all Capabilities in ABC that have child Features.
+


### PR DESCRIPTION
## Add clone-feature Skill

### What This Does
Enables cloning of Jira Features and all their child User Stories while preserving:
- Each issue's original Jira project (multi-project support)
- Parent-child relationships (Capability → Feature → Stories)
- Key fields: summary, description, acceptance criteria, components, labels, fix versions, Size/Story Points

### Use Cases
- **Feature Templates:** Duplicate proven feature blueprints for new initiatives
- **Multi-Team Delivery:** Clone features across different Jira projects and teams
- **Bulk Reuse:** Re-run feature structures with updated context

### Features
- Automatic project distribution (stories stay in their original projects)
- Cloning label for searchability and traceability
- Cross-project parent-child link preservation
- Comprehensive error handling and fallback strategies
- Edge case support (no parent, no children, missing permissions)

### Included Documentation
- **SKILL.md:** 9-step workflow with detailed API calls and edge cases
- **cloning-patterns.md:** Field preservation rules and link directions
- **multi-project-scenarios.md:** Real-world examples with execution lessons
- **troubleshooting-guide.md:** 9 common errors with solutions
- **quick-reference.md:** Compact reference for field IDs, JQL patterns, and workflows

### Testing
Workflow validated on live Jira instance with multi-project Feature cloning (1 Feature + 7 Stories across 2 projects).
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev couldn't review this pull request</strong>
The pull request author does not have access to Rovo Dev.
<!-- /Rovo Dev code review status -->

