### PR TITLE
Add server.json as source of truth for the MCP Registry entry

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "com.atlassian/atlassian-mcp-server",
+  "description": "Connect to Atlassian Jira, Confluence, and Compass to search, create, and manage your work.",
+  "title": "Atlassian Rovo MCP Server",
+  "version": "1.1.2",
+  "websiteUrl": "https://support.atlassian.com/atlassian-rovo-mcp-server/docs/getting-started-with-the-atlassian-remote-mcp-server/",
+  "repository": {
+    "url": "https://github.com/atlassian/atlassian-mcp-server",
+    "source": "github"
+  },
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.atlassian.com/v1/mcp"
+    },
+    {
+      "type": "sse",
+      "url": "https://mcp.atlassian.com/v1/sse"
+    },
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.atlassian.com/v1/mcp/authv2"
+    }
+  ]
+}


### PR DESCRIPTION
## Problem

Reported on the [Atlassian Community](https://community.atlassian.com/) (Atlassian Rovo MCP Server group). The GitHub / official MCP Registry entry **`com.atlassian/atlassian-mcp-server` v1.1.1 (`is_latest: true`)** does not advertise the OAuth 2.1 `authv2` endpoint.

Verified live against `https://api.mcp.github.com/v0/servers/search?q=atlassian`:

```json
"remotes": [
  { "transport_type": "streamable-http", "url": "https://mcp.atlassian.com/v1/mcp" },
  { "transport_type": "sse",             "url": "https://mcp.atlassian.com/v1/sse" }
]
```

**Impact:** organizations that consume server definitions directly from the registry (no manual URL overrides) can't reach `/v1/mcp/authv2`, so the OAuth 2.1 flow isn't available to them via the registry.

## Root cause

There was **no `server.json` in this repo**, so the registry entry was published out-of-band and has since drifted. There was no source of truth and no process to keep it updated.

## Changes

- **Add `server.json`** as the in-repo source of truth for the registry entry. It advertises **all three** remotes so existing clients keep working while `authv2` onboards customers onto the Atlassian auth server:
  - `https://mcp.atlassian.com/v1/mcp` (streamable-http)
  - `https://mcp.atlassian.com/v1/sse` (sse)
  - `https://mcp.atlassian.com/v1/mcp/authv2` (streamable-http)

  Bumped `1.1.1` → `1.1.2`. Validated against the published `2025-12-11` schema.

## Decisions reflected here

- **`/v1/mcp` is retained**, not replaced — clients may cache clientIds / auth-server URLs against it, and `authv2` is an intermediary preview, not yet the stable endpoint.
- **`/v1/sse` is retained** until its end-of-month deprecation is finalised.
- **Connector configs are intentionally NOT changed** to `authv2`. `README.md` and `gemini-extension.json` stay on `/v1/mcp` — we're not migrating connectors to the temporary `authv2` endpoint right before the v2 rollout, and they remain consistent with the registry.
- **Publishing is done manually** via `mcp-publisher` CLI using DNS auth (`com.atlassian` is a reverse-DNS namespace). No GitHub Actions workflow — `server.json` is the source of truth and maintainers publish on demand. See the [internal runbook](https://hello.atlassian.net/wiki/spaces/mcp/pages/7227978497/Publishing+Changes+to+the+MCP+Registry+atlassian-mcp-server) for the exact commands.

## Follow-up required after merge

Once merged, publish `1.1.2` to the registry manually:

```bash
# 1. Retrieve key.pem from Keeper Secrets, then:
mcp-publisher login dns --domain atlassian.com --private-key $(openssl pkey -in key.pem -noout -text | grep -A3 "priv:" | tail -n +2 | tr -d ' :\n')

# 2. Publish (from repo root)
mcp-publisher publish

# 3. Clean up
rm -f key.pem
```