### PR TITLE
Add Gamut to supported clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The Atlassian Rovo MCP Server supports several clients, including:
 
 * [OpenAI ChatGPT](https://platform.openai.com/docs/guides/tools-connectors-mcp)
 * [Claude](https://code.claude.com/docs/en/mcp)
+* [Gamut](https://www.gamut.so/mcp/project-management/atlassian)
 * [GitHub Copilot CLI](https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli)
 * [Gemini CLI](https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/mcp-server.md)
 * [Amazon Quick Suite](https://docs.aws.amazon.com/quicksuite/latest/userguide/mcp-integration.html)


### PR DESCRIPTION
Adds [Gamut](https://www.gamut.so) to the supported clients list.

Gamut is an AI agent platform with native MCP support. Users can connect to the Atlassian Rovo MCP Server directly from the Gamut interface — go to **Connections**, click **Add Connection**, search for **Atlassian**, and authenticate via OAuth.