### PR TITLE
docs: validate & revamp README (correct product/auth facts, add badges)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">Atlassian Rovo MCP Server</h1>
 
 <p align="center">
-  <b>The official Model Context Protocol (MCP) server for Atlassian — a cloud-hosted bridge that gives your AI tools secure, real-time access to Jira, Confluence, Jira Service Management, Bitbucket, and Compass.</b>
+  <b>The official Model Context Protocol (MCP) server for Atlassian: a cloud-hosted bridge that gives your AI tools secure, real-time access to Jira, Confluence, Jira Service Management, Bitbucket, and Compass.</b>
 </p>
 
 <!-- Line 1 · Project -->
@@ -43,7 +43,7 @@
 
 ---
 
-The **official Atlassian Rovo MCP Server** is a cloud-based bridge between your Atlassian Cloud site and compatible external tools. Once configured, it enables those tools to interact with **Jira, Confluence, Jira Service Management, Bitbucket, and Compass** data in real time. This functionality is powered by secure authentication using **OAuth 2.1** or **API tokens**, which ensures all actions respect the user's existing access controls.
+The **official Atlassian Rovo MCP Server** is a cloud-based bridge between your Atlassian Cloud site and compatible external tools. Once configured, it enables those tools to interact with **Jira, Confluence, Jira Service Management, Bitbucket, and Compass** data in real time. Authentication uses **OAuth 2.1** or **API tokens**, so every action respects the user's existing access controls.
 
 With the Atlassian Rovo MCP Server, you can:
 
@@ -51,7 +51,7 @@ With the Atlassian Rovo MCP Server, you can:
 * **Create and update** issues or pages based on natural language commands.
 * **Automate repetitive work**, like generating tickets from meeting notes or specs.
 
-It's designed for developers, content creators, and project teams who use IDEs or AI platforms and want to work with Atlassian data without constantly context switching.
+It's built for developers, content creators, and project teams who work in IDEs or AI tools and want to use Atlassian data without constantly switching context.
 
 ## Contents
 
@@ -110,11 +110,11 @@ Tools are organized by product and intent (read, write, or search). Organization
 
 ## Before you start
 
-Ensure your environment meets the necessary requirements to successfully set up the Atlassian Rovo MCP Server. This section outlines the technical prerequisites and key access considerations.
+Check that your environment meets these requirements before you set up the server.
 
 ### Prerequisites
 
-Before connecting to the Atlassian Rovo MCP Server, review the setup requirements for your environment:
+The requirements depend on how you connect:
 
 #### For supported clients
 
@@ -133,7 +133,7 @@ Before connecting to the Atlassian Rovo MCP Server, review the setup requirement
 
 ## Data and security
 
-Security is a core focus of the Atlassian Rovo MCP Server:
+The server enforces several security controls:
 
 * All traffic is encrypted in transit over **HTTPS (TLS 1.2 or later)**, per [Atlassian's security practices](https://www.atlassian.com/trust/security/security-practices).
 * **OAuth 2.1** and **API token** authentication provide secure access control.
@@ -175,13 +175,13 @@ API token authentication is available for headless, service-style, or non-intera
 * **Admin enablement required:** An organization admin must enable API token authentication for the Rovo MCP Server (**Atlassian Administration → Rovo → Rovo MCP server → Authentication**).
 * **Scoped token required:** Create a personal API token with the scopes required for the tools and data you need to access.
 * **Configuration guide:** [Configure authentication via API token](https://support.atlassian.com/atlassian-rovo-mcp-server/docs/configuring-authentication-via-api-token/)
-* **Admin setting reference:** [Control Atlassian Rovo MCP Server settings — Configure authentication](https://support.atlassian.com/security-and-access-policies/docs/control-atlassian-rovo-mcp-server-settings/#Configure-authentication)
+* **Admin setting reference:** [Control Atlassian Rovo MCP Server settings: Configure authentication](https://support.atlassian.com/security-and-access-policies/docs/control-atlassian-rovo-mcp-server-settings/#Configure-authentication)
 
 ---
 
 ## Example workflows
 
-Once connected, you can perform a variety of useful tasks from within your supported client.
+Once connected, you can run tasks like these from your client.
 
 ### Jira workflows
 
@@ -237,7 +237,7 @@ For [Cursor](https://cursor.com/marketplace/atlassian), skills are part of the m
 
 ## Admin notes: managing access
 
-If you're an admin preparing your organization to use the Atlassian Rovo MCP Server, review these key considerations. For more detailed admin guidance, see:
+If you're an admin preparing your organization to use the Atlassian Rovo MCP Server, review the points below. For more detailed admin guidance, see:
 
 * [Understand Atlassian Rovo MCP Server](https://support.atlassian.com/security-and-access-policies/docs/understand-atlassian-rovo-mcp-server/)
 * [Control Atlassian Rovo MCP Server settings](https://support.atlassian.com/security-and-access-policies/docs/control-atlassian-rovo-mcp-server-settings/)
@@ -289,7 +289,7 @@ To reduce risk, only use trusted MCP clients and servers, carefully review which
 
 ## Support and feedback
 
-Your feedback plays a crucial role in shaping the Atlassian Rovo MCP Server. If you encounter bugs or limitations, or have suggestions:
+We use your feedback to improve the Atlassian Rovo MCP Server. If you hit a bug or limitation, or have a suggestion:
 
 * Visit the [Atlassian Support Portal](https://support.atlassian.com/) to report issues and feature requests.
 * Share your experiences and questions on the [Atlassian Community](https://community.atlassian.com/), and developer-related asks on the [Atlassian Developer Community](https://community.developer.atlassian.com/).

--- a/README.md
+++ b/README.md
@@ -1,35 +1,101 @@
 <p align="center">
-  <img src="images/atlassian_logo_brand_RGB.svg">
+  <img src="images/atlassian_logo_brand_RGB.svg" alt="Atlassian" width="320">
 </p>
 
-# Atlassian MCP Server
+<h1 align="center">Atlassian Rovo MCP Server</h1>
 
-The Atlassian Rovo MCP Server is a cloud-based bridge between your Atlassian Cloud site and compatible external tools. Once configured, it enables those tools to interact with Jira, Compass, and Confluence data in real-time. This functionality is powered by secure authentication using **OAuth 2.1** or **API tokens**, which ensures all actions respect the user's existing access controls.
+<p align="center">
+  <b>A cloud-hosted Model Context Protocol (MCP) bridge that gives your AI tools secure, real-time access to Jira, Confluence, Jira Service Management, Bitbucket, and Compass.</b>
+</p>
+
+<p align="center">
+  <a href="https://github.com/atlassian/atlassian-mcp-server/stargazers"><img src="https://img.shields.io/github/stars/atlassian/atlassian-mcp-server?style=flat&logo=github&color=0052CC" alt="GitHub stars"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/atlassian/atlassian-mcp-server?color=0052CC" alt="License: Apache 2.0"></a>
+  <a href="https://github.com/atlassian/atlassian-mcp-server/commits/main"><img src="https://img.shields.io/github/last-commit/atlassian/atlassian-mcp-server?color=0052CC" alt="Last commit"></a>
+  <img src="https://img.shields.io/badge/Model_Context_Protocol-compatible-000000?logo=modelcontextprotocol&logoColor=white" alt="MCP compatible">
+  <img src="https://img.shields.io/badge/Auth-OAuth_2.1%20%7C%20API%20token-success" alt="Auth: OAuth 2.1 | API token">
+  <a href="CONTRIBUTING.md"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs welcome"></a>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/Jira-0052CC?logo=jira&logoColor=white" alt="Jira">
+  <img src="https://img.shields.io/badge/Confluence-172B4D?logo=confluence&logoColor=white" alt="Confluence">
+  <img src="https://img.shields.io/badge/Jira_Service_Management-0052CC?logo=jirasoftware&logoColor=white" alt="Jira Service Management">
+  <img src="https://img.shields.io/badge/Bitbucket-0052CC?logo=bitbucket&logoColor=white" alt="Bitbucket">
+  <img src="https://img.shields.io/badge/Compass-6554C0?logo=atlassian&logoColor=white" alt="Compass">
+</p>
+
+<p align="center">
+  <a href="https://support.atlassian.com/atlassian-rovo-mcp-server/docs/getting-started-with-the-atlassian-remote-mcp-server/"><b>Getting started</b></a> ·
+  <a href="https://support.atlassian.com/atlassian-rovo-mcp-server/docs/supported-tools/"><b>Supported tools</b></a> ·
+  <a href="https://support.atlassian.com/security-and-access-policies/docs/understand-atlassian-rovo-mcp-server/"><b>Security &amp; admin</b></a> ·
+  <a href="https://community.atlassian.com/"><b>Community</b></a>
+</p>
+
+---
+
+The **Atlassian Rovo MCP Server** is a cloud-based bridge between your Atlassian Cloud site and compatible external tools. Once configured, it enables those tools to interact with **Jira, Confluence, Jira Service Management, Bitbucket, and Compass** data in real time. This functionality is powered by secure authentication using **OAuth 2.1** or **API tokens**, which ensures all actions respect the user's existing access controls.
 
 With the Atlassian Rovo MCP Server, you can:
 
-* **Summarize and search** Jira, Compass, and Confluence content without switching tools.
+* **Summarize and search** Jira, Confluence, Jira Service Management, and Bitbucket content without switching tools.
 * **Create and update** issues or pages based on natural language commands.
 * **Automate repetitive work**, like generating tickets from meeting notes or specs.
 
-It's designed developers, content creators, and project teams who use IDEs or AI platforms and want to work with Atlassian data without constantly context switching.
+It's designed for developers, content creators, and project teams who use IDEs or AI platforms and want to work with Atlassian data without constantly context switching.
+
+## Contents
+
+* [Supported clients](#supported-clients)
+* [Supported products and tools](#supported-products-and-tools)
+* [Before you start](#before-you-start)
+* [Data and security](#data-and-security)
+* [How it works](#how-it-works)
+* [Example workflows](#example-workflows)
+* [Tips and tricks](#tips-and-tricks)
+* [Admin notes: managing access](#admin-notes-managing-access)
+* [Security](#security)
+* [Support and feedback](#support-and-feedback)
+* [Disclaimer](#disclaimer)
 
 ---
 
 ## Supported clients
 
-The Atlassian Rovo MCP Server supports several clients, including:
+The Atlassian Rovo MCP Server works with a growing list of MCP-compatible clients:
 
-* [OpenAI ChatGPT](https://platform.openai.com/docs/guides/tools-connectors-mcp)
-* [Claude](https://code.claude.com/docs/en/mcp)
-* [GitHub Copilot CLI](https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli)
-* [Gemini CLI](https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/mcp-server.md)
-* [Amazon Quick Suite](https://docs.aws.amazon.com/quicksuite/latest/userguide/mcp-integration.html)
-* [Visual Studio Code](https://code.visualstudio.com/)
+| Client | Setup reference |
+| --- | --- |
+| OpenAI ChatGPT | [Connectors / MCP guide](https://platform.openai.com/docs/guides/tools-connectors-mcp) |
+| Claude (Claude.ai, Desktop, and Code) | [Claude MCP docs](https://code.claude.com/docs/en/mcp) |
+| Cursor | [Atlassian on the Cursor marketplace](https://cursor.com/marketplace/atlassian) |
+| Visual Studio Code (GitHub Copilot) | [VS Code MCP docs](https://code.visualstudio.com/docs/copilot/chat/mcp-servers) |
+| GitHub Copilot CLI | [About Copilot CLI](https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli) |
+| Google Gemini CLI | [Gemini CLI MCP docs](https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/mcp-server.md) |
+| Amazon Quick Suite | [MCP integration guide](https://docs.aws.amazon.com/quicksuite/latest/userguide/mcp-integration.html) |
 
-The Atlassian Rovo MCP Server also supports any **local MCP-compatible client** that can run on `localhost` and connect to the server via the `mcp-remote` proxy. This enables custom or third-party integrations that follow the MCP specification.
+The Atlassian Rovo MCP Server also supports any **local MCP-compatible client** that can run on `localhost` and connect to the server via the [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) proxy. This enables custom or third-party integrations that follow the MCP specification.
 
-For detailed setup instructions, refer to your client's own MCP documentation or built-in assistant.
+> [!TIP]
+> For the current, canonical list of supported clients and step-by-step setup, see [Getting started with the Atlassian Rovo MCP Server](https://support.atlassian.com/atlassian-rovo-mcp-server/docs/getting-started-with-the-atlassian-remote-mcp-server/). You can also refer to your client's own MCP documentation or built-in assistant.
+
+---
+
+## Supported products and tools
+
+Tools are organized by product and intent (read, write, or search). Organization admins grant or revoke access at the permission-group level, and each tool inherits the access of its parent group.
+
+| Product | Permission groups | OAuth 2.1 | API token |
+| --- | --- | :---: | :---: |
+| **Jira** | `read` · `write` · `search` | ✅ | ✅ |
+| **Confluence** | `read` · `write` · `search` | ✅ | ✅ |
+| **Jira Service Management** | `read` · `write` | — | ✅ (only) |
+| **Bitbucket Cloud** | `read` · `write` | — | ✅ (scoped, only) |
+| **Compass** | `read` · `write` | ✅ (only) | — |
+| **Atlassian platform** | `read_teamwork_graph` · `search_atlassian` | ✅ | ✅ |
+
+> [!NOTE]
+> Jira Service Management and Bitbucket Cloud tools are available **only via API token authentication**, while Compass tools are available **only via OAuth 2.1**. For the complete, current tool reference, see [Supported tools](https://support.atlassian.com/atlassian-rovo-mcp-server/docs/supported-tools/).
 
 ---
 
@@ -43,15 +109,15 @@ Before connecting to the Atlassian Rovo MCP Server, review the setup requirement
 
 #### For supported clients
 
-* An **Atlassian Cloud site** with Jira, Compass, and/or Confluence
+* An **Atlassian Cloud site** with one or more of Jira, Confluence, Jira Service Management, Bitbucket, or Compass
 * Access to **the client of choice**
 * A modern browser to complete the OAuth 2.1 authorization flow, or API token credentials for headless authentication
 
-#### For IDEs or local clients (Desktop setup)
+#### For IDEs or local clients (desktop setup)
 
-* An **Atlassian Cloud site** with Jira, Compass, and/or Confluence
-* A supported IDE (for example, **Claude desktop, VS Code, or Cursor**) or a custom MCP-compatible client
-* **Node.js v18+** installed to run the local MCP proxy (`mcp-remote`)
+* An **Atlassian Cloud site** with one or more supported products
+* A supported IDE (for example, **Claude Desktop, VS Code, or Cursor**) or a custom MCP-compatible client
+* **Node.js v18+** installed to run the local MCP proxy ([`mcp-remote`](https://www.npmjs.com/package/mcp-remote))
 * A modern browser for completing OAuth login, or API token credentials for headless authentication
 
 ---
@@ -60,9 +126,9 @@ Before connecting to the Atlassian Rovo MCP Server, review the setup requirement
 
 Security is a core focus of the Atlassian Rovo MCP Server:
 
-* All traffic is encrypted via HTTPS using TLS 1.2 or later.
-* OAuth 2.1 and API token authentication provide secure access control.
-* Data access respects Jira, Compass, and Confluence user permissions.
+* All traffic is encrypted in transit over **HTTPS (TLS 1.2 or later)**, per [Atlassian's security practices](https://www.atlassian.com/trust/security/security-practices).
+* **OAuth 2.1** and **API token** authentication provide secure access control.
+* Data access respects Jira, Confluence, Jira Service Management, Bitbucket, and Compass user permissions.
 * If your organization uses IP allowlisting for Atlassian Cloud products, tool calls made through the Atlassian Rovo MCP Server also honor those IP rules.
 
 For a deeper overview of the security model and admin controls, see:
@@ -76,15 +142,18 @@ For a deeper overview of the security model and admin controls, see:
 
 ### Architecture and communication
 
-1. A supported client connects to the server endpoint:
-```
-https://mcp.atlassian.com/v1/mcp
-```
+1. A supported client connects to the server endpoint. The recommended endpoint for most clients is:
+
+   ```
+   https://mcp.atlassian.com/v1/mcp/authv2
+   ```
+
+   The `https://mcp.atlassian.com/v1/mcp` endpoint is also supported (for example, for API token configurations).
 2. Depending on your setup, a secure browser-based OAuth 2.1 flow is triggered, or API token authentication is used.
-3. Once authorized, the client streams contextual data and receives real-time responses from Jira, Compass, or Confluence.
+3. Once authorized, the client streams contextual data and receives real-time responses from your connected Atlassian products.
 
 > [!NOTE]
-> While `/sse` as a server endpoint are supported, we recommend updating any custom clients configured to use `/sse` so they now point to `/mcp`.
+> The legacy Server-Sent Events endpoint (`https://mcp.atlassian.com/v1/sse`) is still supported, but we recommend updating any custom clients configured to use `/sse` so they now point to `/mcp` (or `/mcp/authv2`).
 
 ### Permission management
 
@@ -92,12 +161,12 @@ Access is granted only to data that the user already has permission to view in A
 
 ### API token authentication (headless)
 
-API token authentication is available for headless or long-running client setups.
+API token authentication is available for headless, service-style, or non-interactive client setups (for example, backend systems or automations). It is also **required** for Jira Service Management and Bitbucket Cloud tools.
 
-* **Admin enablement required:** An organization admin must enable API token authentication for Rovo MCP Server.
-* **Scoped token required:** Use a Rovo MCP scoped API token for the required tools and data access.
+* **Admin enablement required:** An organization admin must enable API token authentication for the Rovo MCP Server (**Atlassian Administration → Rovo → Rovo MCP server → Authentication**).
+* **Scoped token required:** Create a personal API token with the scopes required for the tools and data you need to access.
 * **Configuration guide:** [Configure authentication via API token](https://support.atlassian.com/atlassian-rovo-mcp-server/docs/configuring-authentication-via-api-token/)
-* **Admin setting reference:** [Control Atlassian Rovo MCP Server settings - Configure authentication](https://support.atlassian.com/security-and-access-policies/docs/control-atlassian-rovo-mcp-server-settings/#Configure-authentication)
+* **Admin setting reference:** [Control Atlassian Rovo MCP Server settings — Configure authentication](https://support.atlassian.com/security-and-access-policies/docs/control-atlassian-rovo-mcp-server-settings/#Configure-authentication)
 
 ---
 
@@ -120,7 +189,7 @@ Once connected, you can perform a variety of useful tasks from within your suppo
 ### Compass workflows
 
 * **Create**: "Create a service component based on the current repository."
-* **Bulk create**: "Import components and custom fields from this CSV/JSON"
+* **Bulk create**: "Import components and custom fields from this CSV/JSON."
 * **Query**: "What depends on the `api-gateway` service?"
 
 ### Combined tasks
@@ -129,7 +198,7 @@ Once connected, you can perform a variety of useful tasks from within your suppo
 * **Find documentation**: "Fetch the Confluence documentation page linked to this Compass component."
 
 > [!NOTE]
-> Actual capabilities vary, depending on your permission level and client platform.
+> Actual capabilities vary depending on your permission level and client platform.
 
 ---
 
@@ -139,7 +208,7 @@ Once connected, you can perform a variety of useful tasks from within your suppo
 
 Update your [AGENTS.md](https://agents.md/) with the Markdown below to reduce discovery tool calls, save time and tokens, and set maximum search results.
 
-``` MD
+```md
 ## Atlassian Rovo MCP
 
 When connected to atlassian-rovo-mcp:
@@ -151,64 +220,76 @@ When connected to atlassian-rovo-mcp:
 
 ### Use skills
 
-If you're using a desktop client like Claude, you can create or reuse skills for repeated tasks. [See the default Rovo MCP skills](https://github.com/atlassian/atlassian-mcp-server/tree/main/skills)
+If you're using a desktop client like Claude, you can create or reuse skills for repeated tasks. [See the default Rovo MCP skills](https://github.com/atlassian/atlassian-mcp-server/tree/main/skills).
 
 For [Cursor](https://cursor.com/marketplace/atlassian), skills are part of the marketplace plugin.
 
 ---
 
-## Admin notes: Managing access
+## Admin notes: managing access
 
 If you're an admin preparing your organization to use the Atlassian Rovo MCP Server, review these key considerations. For more detailed admin guidance, see:
 
-* [Understand Atlassian Rovo MCP server](https://support.atlassian.com/security-and-access-policies/docs/understand-atlassian-rovo-mcp-server/)
-* [Control Atlassian Rovo MCP server settings](https://support.atlassian.com/security-and-access-policies/docs/control-atlassian-rovo-mcp-server-settings/)
-* [Manage Atlassian Rovo MCP server](https://support.atlassian.com/security-and-access-policies/docs/manage-atlassian-rovo-mcp-server/)
-* [Monitor Atlassian Rovo MCP server activity](https://support.atlassian.com/security-and-access-policies/docs/monitor-atlassian-rovo-mcp-server-activity/)
+* [Understand Atlassian Rovo MCP Server](https://support.atlassian.com/security-and-access-policies/docs/understand-atlassian-rovo-mcp-server/)
+* [Control Atlassian Rovo MCP Server settings](https://support.atlassian.com/security-and-access-policies/docs/control-atlassian-rovo-mcp-server-settings/)
+* [Manage Atlassian Rovo MCP Server](https://support.atlassian.com/security-and-access-policies/docs/manage-atlassian-rovo-mcp-server/)
+* [Monitor Atlassian Rovo MCP Server activity](https://support.atlassian.com/security-and-access-policies/docs/monitor-atlassian-rovo-mcp-server-activity/)
 
 ### Installation and access
 
-* **Not a Marketplace App:**  
-The Atlassian Rovo MCP Server is _not_ installed via the Atlassian Marketplace or the **Manage apps** screen. Instead, it is installed automatically the first time a user completes the OAuth 2.1 (3LO) consent flow (just-in-time or "lazy loading" installation).
-* **First-time installation requirements:**  
-The first user to complete the 3LO consent flow for your site must have access to the Atlassian apps requested by the MCP scopes (for example, Jira and/or Confluence). This ensures the MCP app is registered with the correct permissions for your site.
-* **Subsequent user access:**  
-After the initial install, users with access to only one Atlassian app (for example, just Jira or just Confluence) can also complete the 3LO flow to access that Atlassian app through MCP.
+* **Not a Marketplace app:**
+  The Atlassian Rovo MCP Server is _not_ installed via the Atlassian Marketplace or the **Manage apps** screen. Instead, it is installed automatically the first time a user completes the OAuth 2.1 (3LO) consent flow (just-in-time, or "lazy loading," installation).
+* **First-time installation requirements:**
+  The first user to complete the 3LO consent flow for your site must have access to the Atlassian apps requested by the MCP scopes (for example, Jira and/or Confluence). This ensures the MCP app is registered with the correct permissions for your site.
+* **Subsequent user access:**
+  After the initial install, users with access to only one Atlassian app (for example, just Jira or just Confluence) can also complete the 3LO flow to access that app through MCP.
 
 ### Manage, monitor, and revoke access
 
-* **Admin controls:**  
-Site and organization admins can manage, review, or revoke the MCP app's access from [Manage your organization's Marketplace and third-party apps](https://support.atlassian.com/security-and-access-policies/docs/manage-your-users-third-party-apps/). The app appears in your site's **Connected apps** list after the first successful 3LO consent.
-* **End-user controls:**  
-Individual users can revoke their own app authorizations from their profile settings.
-* **Domain and IP controls:**  
-Use the **Rovo MCP server** settings page in Atlassian Administration to control which external AI tools and domains are allowed to connect. For details, see [Available Atlassian Rovo MCP server domains](https://support.atlassian.com/security-and-access-policies/docs/available-atlassian-rovo-mcp-server-domains/). If your organization uses IP allowlisting for Atlassian Cloud apps, requests made through the Atlassian Rovo MCP Server must originate from an IP address that is allowed by your organization's IP allowlist for the relevant Atlassian app. For configuration details, see [Specify IP addresses for app access](https://support.atlassian.com/security-and-access-policies/docs/specify-ip-addresses-for-product-access/).
-* **Audit logging:** To support monitoring and compliance, key actions performed via the Atlassian Rovo MCP Server are logged in your organization's audit log. Admins can review these logs in Atlassian Administration. For more information, see [Monitor Atlassian Rovo MCP server activity](https://support.atlassian.com/security-and-access-policies/docs/monitor-atlassian-rovo-mcp-server-activity/).
+* **Admin controls:**
+  Site and organization admins can manage, review, or revoke the MCP app's access from [Manage your organization's Marketplace and third-party apps](https://support.atlassian.com/security-and-access-policies/docs/manage-your-users-third-party-apps/). The app appears in your site's **Connected apps** list after the first successful 3LO consent.
+* **Domain controls:**
+  Use the **Rovo MCP server** settings page in Atlassian Administration to control which external AI tools and domains are allowed to connect. By default, Atlassian-supported domains are allowed; you can add trusted domains or block supported ones. Domain controls apply to OAuth 2.1 connections. For details, see [Available Atlassian Rovo MCP server domains](https://support.atlassian.com/security-and-access-policies/docs/available-atlassian-rovo-mcp-server-domains/).
+* **IP controls:**
+  If your organization uses IP allowlisting for Atlassian Cloud apps, requests made through the Atlassian Rovo MCP Server must originate from an IP address allowed by your organization's IP allowlist for the relevant app. For configuration details, see [Specify IP addresses for product access](https://support.atlassian.com/security-and-access-policies/docs/specify-ip-addresses-for-product-access/).
+* **End-user controls:**
+  Individual users can revoke their own app authorizations from their profile settings.
+* **Audit logging:**
+  Every time a tool is used through the Atlassian Rovo MCP Server, an event is recorded in your organization's audit log. Admins can review these in Atlassian Administration under **Insights → Audit log** (filter for _Rovo MCP User Actions_ or search _MCP_). For more information, see [Monitor Atlassian Rovo MCP server activity](https://support.atlassian.com/security-and-access-policies/docs/monitor-atlassian-rovo-mcp-server-activity/).
 
 ### Troubleshooting common issues
 
-* **"Your site admin must authorize this app" error:**  
-A site admin must complete the 3LO consent flow before anyone else can use the MCP app. See ["Your site admin must authorize this app"](https://support.atlassian.com/atlassian-cloud/kb/your-site-admin-must-authorize-this-app-error-in-atlassian-cloud-apps/) error in Atlassian Cloud apps for more details.
-* **"You don't have permission to connect from this IP address. Please ask your admin for access."**  
-This usually indicates that IP allowlisting is enabled and the user's current IP address isn't allowed to access Jira, Confluence, Compass, or Rovo via the Atlassian Rovo MCP Server. Ask your site or organization admin to review the IP allowlist configuration and add the relevant network or VPN IP ranges if appropriate.
-* **App not appearing in Connected apps:**  
-Ensure the user is using the correct Atlassian account and site, and confirm the app is requesting the correct Atlassian app scopes (for example, Jira scopes). If issues persist, check [Manage your organization's Marketplace and third-party apps](https://support.atlassian.com/security-and-access-policies/docs/manage-your-users-third-party-apps/) or contact Atlassian Support. Also verify the user's Jira, Confluence, or Compass permissions in Atlassian Administration.
+* **"Your site admin must authorize this app" error:**
+  A site admin must complete the 3LO consent flow before anyone else can use the MCP app. See ["Your site admin must authorize this app" error in Atlassian Cloud apps](https://support.atlassian.com/atlassian-cloud/kb/your-site-admin-must-authorize-this-app-error-in-atlassian-cloud-apps/) for more details.
+* **"You don't have permission to connect from this IP address. Please ask your admin for access."**
+  This usually indicates that IP allowlisting is enabled and the user's current IP address isn't allowed to access Jira, Confluence, Jira Service Management, Bitbucket, or Compass via the Atlassian Rovo MCP Server. Ask your site or organization admin to review the IP allowlist configuration and add the relevant network or VPN IP ranges if appropriate.
+* **App not appearing in Connected apps:**
+  Ensure the user is using the correct Atlassian account and site, and confirm the app is requesting the correct Atlassian app scopes (for example, Jira scopes). If issues persist, check [Manage your organization's Marketplace and third-party apps](https://support.atlassian.com/security-and-access-policies/docs/manage-your-users-third-party-apps/) or contact Atlassian Support. Also verify the user's product permissions in Atlassian Administration.
+
+---
 
 ## Security
-Model Context Protocol (MCP) lets AI agents connect to tools and Atlassian data using your account’s permissions, which creates powerful workflows but also structural risks. Any MCP client or server you enable (e.g., IDE plugins, desktop apps, hosted MCP servers, “one-click” integrations) can cause an AI agent to perform actions on your behalf.
 
-Large Language models (LLMs) are vulnerable to [prompt injection](https://owasp.org/www-community/attacks/PromptInjection) and related attacks (such as [indirect prompt injection](https://owasp.org/www-community/attacks/PromptInjection) and [tool poisoning](https://invariantlabs.ai/blog/mcp-security-notification-tool-poisoning-attacks)). These attacks can instruct the agent to exfiltrate data or make unintended changes without explicit requests.
+Model Context Protocol (MCP) lets AI agents connect to tools and Atlassian data using your account's permissions, which creates powerful workflows but also structural risks. Any MCP client or server you enable (for example, IDE plugins, desktop apps, hosted MCP servers, or "one-click" integrations) can cause an AI agent to perform actions on your behalf.
 
-To reduce risk, only use trusted MCP clients and servers, carefully review which tools and data each agent can access, and apply least privilege (scoped tokens, minimal project/workspace access). For any high‑impact or destructive action, require human confirmation and monitor audit logs for unusual activity. We strongly recommend reviewing Atlassian’s guidance on MCP risks at [MCP Clients: Understanding the potential security risks](https://www.atlassian.com/blog/artificial-intelligence/mcp-risk-awareness)
+Large language models (LLMs) are vulnerable to [prompt injection](https://owasp.org/www-community/attacks/PromptInjection) and related attacks (such as indirect prompt injection and [tool poisoning](https://invariantlabs.ai/blog/mcp-security-notification-tool-poisoning-attacks)). These attacks can instruct the agent to exfiltrate data or make unintended changes without explicit requests.
+
+To reduce risk, only use trusted MCP clients and servers, carefully review which tools and data each agent can access, and apply least privilege (scoped tokens, minimal project/workspace access). For any high-impact or destructive action, require human confirmation and monitor audit logs for unusual activity. We strongly recommend reviewing Atlassian's guidance on MCP risks at [MCP Clients: Understanding the potential security risks](https://www.atlassian.com/blog/artificial-intelligence/mcp-risk-awareness).
+
+---
 
 ## Support and feedback
-Your feedback plays a crucial role in shaping the Atlassian Rovo MCP Server. If you encounter bugs, limitations, or have suggestions:
-- Visit the [Atlassian Support Portal](https://support.atlassian.com/) Portal to report issues and feature requests.
-- Share your experiences and questions on the [Atlassian Community](https://community.atlassian.com/) and developer-related asks on the [Developer's one](https://developer.atlassian.com/).
-- Go to our [Ecosystem Developer Portal](https://ecosystem.atlassian.net/servicedesk/customer/portal/14/user/login?destination=portal%2F14) if you are building an app and found a bug/issue or have suggestions.
+
+Your feedback plays a crucial role in shaping the Atlassian Rovo MCP Server. If you encounter bugs or limitations, or have suggestions:
+
+* Visit the [Atlassian Support Portal](https://support.atlassian.com/) to report issues and feature requests.
+* Share your experiences and questions on the [Atlassian Community](https://community.atlassian.com/), and developer-related asks on the [Atlassian Developer Community](https://community.developer.atlassian.com/).
+* Go to our [Ecosystem Developer Portal](https://ecosystem.atlassian.net/servicedesk/customer/portal/14/user/login?destination=portal%2F14) if you are building an app and found a bug or issue, or have suggestions.
+
+---
 
 ## Disclaimer
 
-MCP clients can perform actions in Jira, Confluence, and Compass with your existing permissions. Use least privilege, review high‑impact changes before confirming, and monitor audit logs for unusual activity.
+MCP clients can perform actions in Jira, Confluence, Jira Service Management, Bitbucket, and Compass with your existing permissions. Use least privilege, review high-impact changes before confirming, and monitor audit logs for unusual activity.
 
-Learn more: MCP Clients - (Understanding the potential security risks)[https://www.atlassian.com/blog/artificial-intelligence/mcp-risk-awareness]
+Learn more: [MCP Clients: Understanding the potential security risks](https://www.atlassian.com/blog/artificial-intelligence/mcp-risk-awareness).

--- a/README.md
+++ b/README.md
@@ -5,24 +5,33 @@
 <h1 align="center">Atlassian Rovo MCP Server</h1>
 
 <p align="center">
-  <b>A cloud-hosted Model Context Protocol (MCP) bridge that gives your AI tools secure, real-time access to Jira, Confluence, Jira Service Management, Bitbucket, and Compass.</b>
+  <b>The official Model Context Protocol (MCP) server for Atlassian — a cloud-hosted bridge that gives your AI tools secure, real-time access to Jira, Confluence, Jira Service Management, Bitbucket, and Compass.</b>
 </p>
 
+<!-- Line 1 · Project -->
 <p align="center">
-  <a href="https://github.com/atlassian/atlassian-mcp-server/stargazers"><img src="https://img.shields.io/github/stars/atlassian/atlassian-mcp-server?style=flat&logo=github&color=0052CC" alt="GitHub stars"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/github/license/atlassian/atlassian-mcp-server?color=0052CC" alt="License: Apache 2.0"></a>
-  <a href="https://github.com/atlassian/atlassian-mcp-server/commits/main"><img src="https://img.shields.io/github/last-commit/atlassian/atlassian-mcp-server?color=0052CC" alt="Last commit"></a>
-  <img src="https://img.shields.io/badge/Model_Context_Protocol-compatible-000000?logo=modelcontextprotocol&logoColor=white" alt="MCP compatible">
-  <img src="https://img.shields.io/badge/Auth-OAuth_2.1%20%7C%20API%20token-success" alt="Auth: OAuth 2.1 | API token">
-  <a href="CONTRIBUTING.md"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs welcome"></a>
+  <img src="https://img.shields.io/badge/Official-Atlassian-0052CC?logo=atlassian&logoColor=white" alt="Official Atlassian Server">
+  <a href="https://github.com/atlassian/atlassian-mcp-server/stargazers"><img src="https://img.shields.io/github/stars/atlassian/atlassian-mcp-server?style=flat&logo=github&label=Stars&color=0052CC" alt="GitHub stars"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/atlassian/atlassian-mcp-server?label=License&color=0052CC" alt="License: Apache 2.0"></a>
+  <img src="https://img.shields.io/badge/Status-Generally_Available-2EBC4F" alt="Status: Generally Available">
 </p>
 
+<!-- Line 2 · Protocol & access -->
+<p align="center">
+  <img src="https://img.shields.io/badge/Model_Context_Protocol-compatible-000000?logo=modelcontextprotocol&logoColor=white" alt="Model Context Protocol compatible">
+  <a href="server.json"><img src="https://img.shields.io/badge/MCP_Registry-com.atlassian-000000?logo=modelcontextprotocol&logoColor=white" alt="MCP Registry: com.atlassian"></a>
+  <img src="https://img.shields.io/badge/Auth-OAuth_2.1%20%7C%20API%20token-2EBC4F" alt="Auth: OAuth 2.1 or API token">
+  <img src="https://img.shields.io/badge/Hosting-Atlassian_Cloud-0052CC?logo=atlassian&logoColor=white" alt="Hosting: Atlassian Cloud">
+</p>
+
+<!-- Line 3 · Supported products. Compass & Rovo have no simple-icons slug, so they use the official @atlaskit/logo (v20) tile glyphs embedded as SVG data URIs. -->
 <p align="center">
   <img src="https://img.shields.io/badge/Jira-0052CC?logo=jira&logoColor=white" alt="Jira">
   <img src="https://img.shields.io/badge/Confluence-172B4D?logo=confluence&logoColor=white" alt="Confluence">
   <img src="https://img.shields.io/badge/Jira_Service_Management-0052CC?logo=jirasoftware&logoColor=white" alt="Jira Service Management">
   <img src="https://img.shields.io/badge/Bitbucket-0052CC?logo=bitbucket&logoColor=white" alt="Bitbucket">
-  <img src="https://img.shields.io/badge/Compass-6554C0?logo=atlassian&logoColor=white" alt="Compass">
+  <img src="https://img.shields.io/badge/Compass-94C748?logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iIzk0Yzc0OCIgZD0iTTAgNmE2IDYgMCAwIDEgNi02aDEyYTYgNiAwIDAgMSA2IDZ2MTJhNiA2IDAgMCAxLTYgNkg2YTYgNiAwIDAgMS02LTZ6Ii8+PHBhdGggZmlsbD0iIzEwMTIxNCIgZD0iTTEyLjc1IDcuODc3di0zLjM3bDYuMTYtLjAwN2guMDA3YS41OS41OSAwIDAgMSAuNTgzLjU5OHY2LjE0N2gtMy4zNjZWNy44Nzd6Ii8+PHBhdGggZmlsbD0iIzEwMTIxNCIgZD0iTTEyLjc1IDE0LjYxNXYtMy4zN2gzLjM2OHY2LjE2NWEuNTkuNTkgMCAwIDEtLjU5MS41OUg2LjU4M0EuNTkuNTkgMCAwIDEgNiAxNy40MDJWOC40NjdhLjU5LjU5IDAgMCAxIC41OTEtLjU5aDYuMTZ2My4zNjhIOS4zNzN2My4zN3oiLz48L3N2Zz4=" alt="Compass">
+  <img src="https://img.shields.io/badge/Rovo-1868DB?logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iIzE4NjhkYiIgZD0iTTAgNmE2IDYgMCAwIDEgNi02aDEyYTYgNiAwIDAgMSA2IDZ2MTJhNiA2IDAgMCAxLTYgNkg2YTYgNiAwIDAgMS02LTZ6Ii8+PHBhdGggZmlsbD0iI2ZmZmZmZiIgZD0iTTExLjA1NyA1LjI1N2ExLjU3IDEuNTcgMCAwIDEgMS41MzkuMDE1bDQuNjIxIDIuNjY4Yy40ODQuMjc5Ljc4My43OTcuNzgzIDEuMzU0djUuMzM2YTEuNTYgMS41NiAwIDAgMS0uNzgyIDEuMzU1bC0zLjQ3NCAyLjAwNWEyIDIgMCAwIDAgLjEyLS42OTF2LTUuMzM3YzAtLjczMy0uMzktMS40MDktMS4wMjYtMS43NzRsLTIuNTktMS40OTVWNi42MjZxLjAwMS0uMjQ2LjA3NC0uNDczYy4xMTctLjM2NC4zNjYtLjY4LjcwNy0uODc3eiIvPjxwYXRoIGZpbGw9IiNmZmZmZmYiIGQ9Ik05Ljg4MSA1Ljk0IDYuNDA4IDcuOTQ1QTEuNTYgMS41NiAwIDAgMCA1LjYyNSA5LjN2NS4zMzdjMCAuNTU3LjMgMS4wNzUuNzgzIDEuMzU0bDQuNjIxIDIuNjY4Yy40NzUuMjc0IDEuMDYuMjc5IDEuNTM5LjAxNWwuMDI3LS4wMTlhMS41NyAxLjU3IDAgMCAwIC43ODEtMS4zNXYtMi4wNjdsLTIuNTg5LTEuNDk1YTIuMDUgMi4wNSAwIDAgMS0xLjAyNi0xLjc3NVY2LjYzMWEyIDIgMCAwIDEgLjEyLS42OTEiLz48L3N2Zz4=&amp;logoColor=white" alt="Rovo">
 </p>
 
 <p align="center">
@@ -34,7 +43,7 @@
 
 ---
 
-The **Atlassian Rovo MCP Server** is a cloud-based bridge between your Atlassian Cloud site and compatible external tools. Once configured, it enables those tools to interact with **Jira, Confluence, Jira Service Management, Bitbucket, and Compass** data in real time. This functionality is powered by secure authentication using **OAuth 2.1** or **API tokens**, which ensures all actions respect the user's existing access controls.
+The **official Atlassian Rovo MCP Server** is a cloud-based bridge between your Atlassian Cloud site and compatible external tools. Once configured, it enables those tools to interact with **Jira, Confluence, Jira Service Management, Bitbucket, and Compass** data in real time. This functionality is powered by secure authentication using **OAuth 2.1** or **API tokens**, which ensures all actions respect the user's existing access controls.
 
 With the Atlassian Rovo MCP Server, you can:
 


### PR DESCRIPTION
## What & why

This PR revamps `README.md` for our public repo. Every line was reviewed and validated against the public Atlassian support docs (support.atlassian.com / SAC), and the doc was beautified for a public audience.

<img width="1781" height="1116" alt="image" src="https://github.com/user-attachments/assets/950b062b-b7b6-4d2a-91a2-e3e053c36ff9" />


## ✅ Validation against SAC (what changed and why)

| Area | Before | After | Source |
| --- | --- | --- | --- |
| Supported products | Jira, Confluence, Compass only | Adds **Jira Service Management** and **Bitbucket Cloud** | [Supported tools](https://support.atlassian.com/atlassian-rovo-mcp-server/docs/supported-tools/), [Getting started](https://support.atlassian.com/atlassian-rovo-mcp-server/docs/getting-started-with-the-atlassian-remote-mcp-server/) |
| Per-product auth | Not stated | New table: JSM & Bitbucket = **API token only**, Compass = **OAuth 2.1 only**, Jira/Confluence = both | [Supported tools](https://support.atlassian.com/atlassian-rovo-mcp-server/docs/supported-tools/) |
| Endpoint | Only `/v1/mcp` | Recommends **`/v1/mcp/authv2`** (matches our own `.mcp.json`), keeps `/v1/mcp`, clarifies legacy `/v1/sse` | `server.json`, `.mcp.json`, Getting started |
| Audit logging | Generic "logged in audit log" | Adds specifics: **Insights → Audit log**, filter _Rovo MCP User Actions_ | [Monitor activity](https://support.atlassian.com/security-and-access-policies/docs/monitor-atlassian-rovo-mcp-server-activity/) |
| Domain controls | Implied | Clarifies default-allow + OAuth-2.1-only scope | [Available domains](https://support.atlassian.com/security-and-access-policies/docs/available-atlassian-rovo-mcp-server-domains/) |
| Supported clients | Plain list | Linked table; **adds Cursor**, fixes VS Code MCP doc link | Getting started |

All other admin/security claims (3LO / just-in-time install, "your site admin must authorize", IP allowlisting, Connected apps, scoped API tokens) were confirmed against the linked SAC pages and kept.

### Fixes
- "It's designed developers" → "It's designed **for** developers".
- Malformed disclaimer link `(text)[url]` → proper `[text](url)`.
- Broken grammar in the `/sse` note rewritten.
- Developer community link updated to `community.developer.atlassian.com`.

### ⚠️ One claim to confirm
- **TLS 1.2+**: not stated on the Rovo-specific SAC pages, so I cited [Atlassian's general security practices](https://www.atlassian.com/trust/security/security-practices) (which document TLS 1.2+) and softened the wording. Please confirm this is the right citation, or point me to a Rovo-specific source.

> **Node.js v18+** for `mcp-remote` is not on SAC but is corroborated by the `mcp-remote` package itself — kept as-is.

## 💅 Beautification
- Centered header logo, an "official" value-prop tagline (also helps discoverability), and quick-nav links.
- Badges grouped into **3 rows** via `shields.io`:
  - **Project** — Official Atlassian · Stars · License · Status: Generally Available
  - **Protocol & access** — MCP compatible · MCP Registry · Auth (OAuth 2.1 / API token) · Hosting: Atlassian Cloud
  - **Products** — Jira · Confluence · Jira Service Management · Bitbucket · Compass · Rovo
- Dropped `last commit` and `PRs welcome` — misleading for a docs-only repo (the server source is private/internal, not this repository).
- **Compass and Rovo** use the official `@atlaskit/logo` (v20) tile glyphs embedded as SVG data URIs, since neither has a simple-icons slug.
- Table of contents, supported-clients and supported-products tables, and `> [!NOTE]` / `> [!TIP]` callouts.

## 🔗 Link check
All 27 links in the README were HEAD-checked and return 200 (the one 404 found during review was fixed before commit).

## Notes
- Docs-only change; no code touched.
