### PR TITLE
ci: add plugin template validation workflow (changeset-based)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: Validate plugin templates
+
+# Runs the repo's manifest/skill validator on changes that can affect it.
+# Prose-only doc edits (README, CONTRIBUTING, images, etc.) are filtered out so
+# the check does not run on basic documentation changes. Note: skill Markdown
+# (SKILL.md and other component frontmatter) is intentionally NOT ignored, since
+# scripts/validate-template.mjs validates that frontmatter.
+
+on:
+  pull_request:
+    paths-ignore:
+      - 'README.md'
+      - 'CONTRIBUTING.md'
+      - 'CODE_OF_CONDUCT.md'
+      - 'SECURITY.md'
+      - 'LICENSE'
+      - 'CODEOWNERS'
+      - 'images/**'
+      - 'assets/**'
+      - '**/*.svg'
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'README.md'
+      - 'CONTRIBUTING.md'
+      - 'CODE_OF_CONDUCT.md'
+      - 'SECURITY.md'
+      - 'LICENSE'
+      - 'CODEOWNERS'
+      - 'images/**'
+      - 'assets/**'
+      - '**/*.svg'
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate plugin & skill templates
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Validate templates
+        run: node scripts/validate-template.mjs


### PR DESCRIPTION
## What

Adds a lightweight GitHub Actions workflow (`.github/workflows/ci.yml`) that runs the existing `scripts/validate-template.mjs` validator on PRs and pushes to `main`.

The validator checks the plugin / marketplace manifests, `SKILL.md` (and other component) frontmatter, and that referenced paths exist. It uses only Node built-ins — no `npm install`, no dependencies.

## Why

This repo currently has **no committed CI**. A small validation check is far more useful here than heavyweight SAST: it catches broken manifests and malformed skill frontmatter before merge, which is the realistic failure mode for a skills/plugin repo.

## Changeset behaviour

Per the request to **not run on basic doc changes**, the workflow uses `paths-ignore` to skip prose-only edits:

- `README.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, `LICENSE`, `CODEOWNERS`
- `images/**`, `assets/**`, `**/*.svg`

> Note: skill Markdown (`SKILL.md` and other component frontmatter) is **intentionally not ignored**, because `validate-template.mjs` validates that frontmatter — so skill edits still trigger the check.

## Notes

- Verified locally: `node scripts/validate-template.mjs` → `Validation passed.` (exit 0).
- The **CLA** check is unaffected — it's an external Atlassian commit status, not a workflow.
- Does **not** touch CodeQL. Converting CodeQL to changeset-based (path-filtered) requires switching it from "Default setup" to "Advanced setup" in repo Settings, which a committed file alone can't do; happy to follow up with that separately.
