### PR TITLE
chore: add GitHub issue forms with support-channel signposting

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,7 +12,7 @@ body:
 
         Two things worth knowing first:
 
-        - Nobody watches this repo full time, so we can't promise a reply by any particular date. If you're blocked or need an answer soon, [Atlassian Support](https://support.atlassian.com/) and the [Atlassian Community](https://community.atlassian.com/) are staffed and usually quicker.
+        - Nobody watches this repo full time, so we can't promise a reply by any particular date. If you're blocked or need an answer soon, [Atlassian Support](https://support.atlassian.com/) and the [Atlassian Community](https://community.atlassian.com/forums/Atlassian-Rovo-MCP-Server/gh-p/AtlassianMCPServer) are staffed and usually quicker.
         - If the bug is in the hosted server itself (something `mcp.atlassian.com` does, sign-in, tool behavior, permissions), Support is the better route. Not sure which it is? File here anyway and we'll point you the right way.
   - type: checkboxes
     id: dedup

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,17 +1,19 @@
 name: 🐞 Bug report
-description: "Report a problem with this repository's contents: README/docs, client manifests, server.json, or skills."
+description: "Something wrong in this repo's contents: README/docs, client manifests, server.json, or skills."
 title: "[Bug]: "
 labels: ["bug", "needs-triage"]
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for filing a bug. We welcome reports about this repository's contents: the README and docs, the client manifests (`.mcp.json`, `.claude-plugin/`, `.cursor-plugin/`, `gemini-extension.json`), the MCP registry entry (`server.json`), and the [skills](https://github.com/atlassian/atlassian-mcp-server/tree/main/skills).
+        Thanks for taking the time to report a bug.
 
-        A couple of honest notes so you know what to expect:
+        This is the right place for problems with what lives in this repo: the README and docs, the client manifests (`.mcp.json`, `.claude-plugin/`, `.cursor-plugin/`, `gemini-extension.json`), the MCP registry entry (`server.json`), and the [skills](https://github.com/atlassian/atlassian-mcp-server/tree/main/skills).
 
-        - This repo isn't actively monitored, and we don't offer a response-time commitment here. If you're blocked or need a timely answer, [Atlassian Support](https://support.atlassian.com/) and the [Atlassian Community](https://community.atlassian.com/) are managed channels and will usually be faster.
-        - Bugs in the hosted server itself (errors from `mcp.atlassian.com`, authentication, tool behavior, permissions) are best raised with Support. If you're not sure, file here anyway and we'll help point you to the right place.
+        Two things worth knowing first:
+
+        - Nobody watches this repo full time, so we can't promise a reply by any particular date. If you're blocked or need an answer soon, [Atlassian Support](https://support.atlassian.com/) and the [Atlassian Community](https://community.atlassian.com/) are staffed and usually quicker.
+        - If the bug is in the hosted server itself (something `mcp.atlassian.com` does, sign-in, tool behavior, permissions), Support is the better route. Not sure which it is? File here anyway and we'll point you the right way.
   - type: checkboxes
     id: dedup
     attributes:
@@ -34,26 +36,26 @@ body:
   - type: input
     id: skill-name
     attributes:
-      label: Skill name (if applicable)
+      label: Skill name (if it's about a skill)
       placeholder: e.g. triage-issue
   - type: textarea
     id: what-happened
     attributes:
       label: What happened?
-      description: A clear description of the bug, including what is wrong and where you found it.
+      description: Tell us what's wrong and where you ran into it.
     validations:
       required: true
   - type: textarea
     id: expected
     attributes:
-      label: What did you expect to happen?
+      label: What did you expect instead?
     validations:
       required: true
   - type: textarea
     id: repro
     attributes:
       label: Steps to reproduce
-      description: If relevant, include exact steps and any error output.
+      description: If you can, list the steps and paste any error output.
       placeholder: |
         1. ...
         2. ...
@@ -61,10 +63,10 @@ body:
   - type: input
     id: client
     attributes:
-      label: MCP client & version (if relevant)
+      label: MCP client and version (if it's relevant)
       placeholder: e.g. Claude Desktop 1.2.3, Cursor 0.42, VS Code Copilot
   - type: textarea
     id: extra
     attributes:
       label: Anything else?
-      description: Links, screenshots, or additional context.
+      description: Links, screenshots, or anything else that helps.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,7 +12,7 @@ body:
 
         Two things worth knowing first:
 
-        - Nobody watches this repo full time, so we can't promise a reply by any particular date. If you're blocked or need an answer soon, [Atlassian Support](https://support.atlassian.com/) and the [Atlassian Community](https://community.atlassian.com/forums/Atlassian-Rovo-MCP-Server/gh-p/AtlassianMCPServer) are staffed and usually quicker.
+        - We don't watch this repo full time, so we can't promise a reply by a set date. If you're blocked or need an answer soon, [Atlassian Support](https://support.atlassian.com/) and the [Atlassian Community](https://community.atlassian.com/forums/Atlassian-Rovo-MCP-Server/gh-p/AtlassianMCPServer) are staffed and usually quicker.
         - If the bug is in the hosted server itself (something `mcp.atlassian.com` does, sign-in, tool behavior, permissions), Support is the better route. Not sure which it is? File here anyway and we'll point you the right way.
   - type: checkboxes
     id: dedup

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,71 @@
+name: 🐞 Bug report (this repository)
+description: Report a problem with this repository's contents — README/docs, client manifests, MCP registry metadata, or skills.
+title: "[Bug]: "
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a report! 🙏
+
+        **This tracker is for the _contents of this repository_** — the README and docs, the client manifests (`.mcp.json`, `.claude-plugin/`, `.cursor-plugin/`, `gemini-extension.json`), the MCP registry entry (`server.json`), and the [skills](https://github.com/atlassian/atlassian-mcp-server/tree/main/skills).
+
+        ⚠️ **Problems with the hosted server itself** — errors from `mcp.atlassian.com`, OAuth 2.1 / API-token authentication, tool behavior, permissions, or any Atlassian product — are handled by **[Atlassian Support](https://support.atlassian.com/)**, not here. See the links on the "New issue" page.
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Confirm scope
+      options:
+        - label: This is about the contents of this repository, not the hosted server or an Atlassian product.
+          required: true
+        - label: I searched [existing issues](https://github.com/atlassian/atlassian-mcp-server/issues) and didn't find a duplicate.
+          required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      options:
+        - README / documentation
+        - Client manifest (Claude / Cursor / Gemini / .mcp.json)
+        - MCP registry entry (server.json)
+        - Skill
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: skill-name
+    attributes:
+      label: Skill name (if applicable)
+      placeholder: e.g. triage-issue
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug, including what is wrong and where you found it.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: If relevant, include exact steps and any error output.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+  - type: input
+    id: client
+    attributes:
+      label: MCP client & version (if relevant)
+      placeholder: e.g. Claude Desktop 1.2.3, Cursor 0.42, VS Code Copilot
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: Links, screenshots, or additional context.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,23 +1,22 @@
-name: 🐞 Bug report (this repository)
-description: Report a problem with this repository's contents — README/docs, client manifests, MCP registry metadata, or skills.
+name: 🐞 Bug report
+description: "Report a problem with this repository's contents: README/docs, client manifests, server.json, or skills."
 title: "[Bug]: "
 labels: ["bug", "needs-triage"]
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to file a report! 🙏
+        Thanks for filing a bug. We welcome reports about this repository's contents: the README and docs, the client manifests (`.mcp.json`, `.claude-plugin/`, `.cursor-plugin/`, `gemini-extension.json`), the MCP registry entry (`server.json`), and the [skills](https://github.com/atlassian/atlassian-mcp-server/tree/main/skills).
 
-        **This tracker is for the _contents of this repository_** — the README and docs, the client manifests (`.mcp.json`, `.claude-plugin/`, `.cursor-plugin/`, `gemini-extension.json`), the MCP registry entry (`server.json`), and the [skills](https://github.com/atlassian/atlassian-mcp-server/tree/main/skills).
+        A couple of honest notes so you know what to expect:
 
-        ⚠️ **Problems with the hosted server itself** — errors from `mcp.atlassian.com`, OAuth 2.1 / API-token authentication, tool behavior, permissions, or any Atlassian product — are handled by **[Atlassian Support](https://support.atlassian.com/)**, not here. See the links on the "New issue" page.
+        - This repo isn't actively monitored, and we don't offer a response-time commitment here. If you're blocked or need a timely answer, [Atlassian Support](https://support.atlassian.com/) and the [Atlassian Community](https://community.atlassian.com/) are managed channels and will usually be faster.
+        - Bugs in the hosted server itself (errors from `mcp.atlassian.com`, authentication, tool behavior, permissions) are best raised with Support. If you're not sure, file here anyway and we'll help point you to the right place.
   - type: checkboxes
-    id: scope
+    id: dedup
     attributes:
-      label: Confirm scope
+      label: Before you start
       options:
-        - label: This is about the contents of this repository, not the hosted server or an Atlassian product.
-          required: true
         - label: I searched [existing issues](https://github.com/atlassian/atlassian-mcp-server/issues) and didn't find a duplicate.
           required: true
   - type: dropdown
@@ -29,7 +28,7 @@ body:
         - Client manifest (Claude / Cursor / Gemini / .mcp.json)
         - MCP registry entry (server.json)
         - Skill
-        - Other
+        - Not sure / other
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -8,8 +8,8 @@ contact_links:
       itself (mcp.atlassian.com, sign-in, API tokens, permissions, or any
       Atlassian product), Atlassian Support is staffed and usually faster.
   - name: 💬 Questions and usage help
-    url: https://community.atlassian.com/
-    about: Ask how-to questions and swap tips on the Atlassian Community.
+    url: https://community.atlassian.com/forums/Atlassian-Rovo-MCP-Server/gh-p/AtlassianMCPServer
+    about: Ask how-to questions and swap tips in the Atlassian Rovo MCP Server community.
   - name: 👩‍💻 Developer and API questions
     url: https://community.developer.atlassian.com/
     about: For Atlassian developer platform and API questions, try the Developer Community.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,8 +3,8 @@ contact_links:
   - name: 🛠️ Need a faster reply, or hit a product issue?
     url: https://support.atlassian.com/
     about: >-
-      Heads up: nobody watches this repo full time, so there's no guaranteed
-      reply time. If you're stuck, or the problem is with the hosted server
+      Heads up: we don't watch this repo full time, so we can't promise a
+      reply here. If you're stuck, or the problem is with the hosted server
       itself (mcp.atlassian.com, sign-in, API tokens, permissions, or any
       Atlassian product), Atlassian Support is staffed and usually faster.
   - name: 💬 Questions and usage help

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,20 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 🛠️ Product, server, or authentication problem
+    url: https://support.atlassian.com/
+    about: >-
+      Issues with the hosted Atlassian Rovo MCP Server (mcp.atlassian.com) —
+      tool errors, OAuth 2.1 / API-token authentication, permissions, or
+      Atlassian product behavior — are handled by Atlassian Support, not in this
+      repository.
+  - name: 💬 Questions & usage help
+    url: https://community.atlassian.com/
+    about: Ask how-to questions and share tips on the Atlassian Community.
+  - name: 👩‍💻 Developer & API questions
+    url: https://community.developer.atlassian.com/
+    about: For Atlassian developer platform and API questions, use the Developer Community.
+  - name: 🔒 Report a security vulnerability
+    url: https://www.atlassian.com/trust/security/report-a-vulnerability
+    about: >-
+      Please report security vulnerabilities privately to the Atlassian security
+      team. Do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,21 +1,20 @@
 blank_issues_enabled: false
 contact_links:
-  - name: 🛠️ Need a faster or guaranteed response?
+  - name: 🛠️ Need a faster reply, or hit a product issue?
     url: https://support.atlassian.com/
     about: >-
-      This repository isn't actively monitored and has no response-time
-      commitment. For anything time-sensitive, or for problems with the hosted
-      server (mcp.atlassian.com behavior, OAuth 2.1 / API-token auth,
-      permissions, or Atlassian product behavior), Atlassian Support is a
-      managed channel and will usually be faster.
-  - name: 💬 Questions & usage help
+      Heads up: nobody watches this repo full time, so there's no guaranteed
+      reply time. If you're stuck, or the problem is with the hosted server
+      itself (mcp.atlassian.com, sign-in, API tokens, permissions, or any
+      Atlassian product), Atlassian Support is staffed and usually faster.
+  - name: 💬 Questions and usage help
     url: https://community.atlassian.com/
-    about: Ask how-to questions and share tips on the Atlassian Community.
-  - name: 👩‍💻 Developer & API questions
+    about: Ask how-to questions and swap tips on the Atlassian Community.
+  - name: 👩‍💻 Developer and API questions
     url: https://community.developer.atlassian.com/
-    about: For Atlassian developer platform and API questions, use the Developer Community.
+    about: For Atlassian developer platform and API questions, try the Developer Community.
   - name: 🔒 Report a security vulnerability
     url: https://www.atlassian.com/trust/security/report-a-vulnerability
     about: >-
-      Please report security vulnerabilities privately to the Atlassian security
-      team. Do not open a public issue.
+      Found a security problem? Report it privately to the Atlassian security
+      team. Please don't open a public issue.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,12 +1,13 @@
 blank_issues_enabled: false
 contact_links:
-  - name: 🛠️ Product, server, or authentication problem
+  - name: 🛠️ Need a faster or guaranteed response?
     url: https://support.atlassian.com/
     about: >-
-      Issues with the hosted Atlassian Rovo MCP Server (mcp.atlassian.com) —
-      tool errors, OAuth 2.1 / API-token authentication, permissions, or
-      Atlassian product behavior — are handled by Atlassian Support, not in this
-      repository.
+      This repository isn't actively monitored and has no response-time
+      commitment. For anything time-sensitive, or for problems with the hosted
+      server (mcp.atlassian.com behavior, OAuth 2.1 / API-token auth,
+      permissions, or Atlassian product behavior), Atlassian Support is a
+      managed channel and will usually be faster.
   - name: 💬 Questions & usage help
     url: https://community.atlassian.com/
     about: Ask how-to questions and share tips on the Atlassian Community.

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -12,7 +12,7 @@ body:
 
         Two things worth knowing first:
 
-        - Nobody watches this repo full time, so there's no guaranteed reply time here. If you need an answer soon, the [Atlassian Community](https://community.atlassian.com/forums/Atlassian-Rovo-MCP-Server/gh-p/AtlassianMCPServer) is staffed and usually quicker.
+        - We don't watch this repo full time, so we can't promise a quick reply here. If you need an answer soon, the [Atlassian Community](https://community.atlassian.com/forums/Atlassian-Rovo-MCP-Server/gh-p/AtlassianMCPServer) is staffed and usually quicker.
         - Want a new tool or product capability in the hosted Atlassian Rovo MCP Server itself? Raise it through [Atlassian Support](https://support.atlassian.com/) or the [Atlassian Community](https://community.atlassian.com/forums/Atlassian-Rovo-MCP-Server/gh-p/AtlassianMCPServer) so it actually reaches the product team.
   - type: checkboxes
     id: dedup

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -12,8 +12,8 @@ body:
 
         Two things worth knowing first:
 
-        - Nobody watches this repo full time, so there's no guaranteed reply time here. If you need an answer soon, the [Atlassian Community](https://community.atlassian.com/) is staffed and usually quicker.
-        - Want a new tool or product capability in the hosted Atlassian Rovo MCP Server itself? Raise it through [Atlassian Support](https://support.atlassian.com/) or the [Atlassian Community](https://community.atlassian.com/) so it actually reaches the product team.
+        - Nobody watches this repo full time, so there's no guaranteed reply time here. If you need an answer soon, the [Atlassian Community](https://community.atlassian.com/forums/Atlassian-Rovo-MCP-Server/gh-p/AtlassianMCPServer) is staffed and usually quicker.
+        - Want a new tool or product capability in the hosted Atlassian Rovo MCP Server itself? Raise it through [Atlassian Support](https://support.atlassian.com/) or the [Atlassian Community](https://community.atlassian.com/forums/Atlassian-Rovo-MCP-Server/gh-p/AtlassianMCPServer) so it actually reaches the product team.
   - type: checkboxes
     id: dedup
     attributes:

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,17 +1,19 @@
-name: 💡 Enhancement / feature request
-description: "Suggest an improvement to this repository: a new or improved skill, client manifest, docs, or registry metadata."
+name: 💡 Enhancement or feature request
+description: "An idea to improve this repo: a new or better skill, client manifest, docs, or registry metadata."
 title: "[Enhancement]: "
 labels: ["enhancement", "needs-triage"]
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for the suggestion. We welcome ideas for this repository's contents: skills, client manifests, docs, and registry metadata.
+        Thanks for the idea.
 
-        Two honest notes:
+        This is the place for improvements to what's in this repo: skills, client manifests, docs, and registry metadata.
 
-        - This repo isn't actively monitored and has no response-time commitment. If you need a timely answer, the [Atlassian Community](https://community.atlassian.com/) is a faster, managed channel.
-        - To request new tools or product capabilities in the hosted Atlassian Rovo MCP Server, please use [Atlassian Support](https://support.atlassian.com/) or the [Atlassian Community](https://community.atlassian.com/) so it reaches the product team.
+        Two things worth knowing first:
+
+        - Nobody watches this repo full time, so there's no guaranteed reply time here. If you need an answer soon, the [Atlassian Community](https://community.atlassian.com/) is staffed and usually quicker.
+        - Want a new tool or product capability in the hosted Atlassian Rovo MCP Server itself? Raise it through [Atlassian Support](https://support.atlassian.com/) or the [Atlassian Community](https://community.atlassian.com/) so it actually reaches the product team.
   - type: checkboxes
     id: dedup
     attributes:
@@ -36,19 +38,19 @@ body:
     id: problem
     attributes:
       label: What problem does this solve?
-      description: What are you trying to do, and what is missing or awkward today?
+      description: What are you trying to do, and what's missing or awkward today?
     validations:
       required: true
   - type: textarea
     id: proposal
     attributes:
-      label: Proposed solution
+      label: What would you like to see?
     validations:
       required: true
   - type: textarea
     id: alternatives
     attributes:
-      label: Alternatives considered
+      label: Anything you've already tried or considered?
   - type: textarea
     id: extra
     attributes:

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,52 @@
+name: 💡 Enhancement / feature request
+description: Suggest an improvement to this repository — a new or improved skill, client manifest, docs, or registry metadata.
+title: "[Enhancement]: "
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion! 🙏
+
+        **This tracker covers the _contents of this repository_.** To request new **tools** or **product capabilities** in the hosted Atlassian Rovo MCP Server, please use the [Atlassian Support Portal](https://support.atlassian.com/) or [Atlassian Community](https://community.atlassian.com/) so it reaches the product team.
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Confirm scope
+      options:
+        - label: I searched [existing issues](https://github.com/atlassian/atlassian-mcp-server/issues) and didn't find a duplicate.
+          required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: What would you like to improve?
+      options:
+        - New skill
+        - Existing skill
+        - Client manifest / new client support
+        - README / documentation
+        - MCP registry entry (server.json)
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: What are you trying to do, and what is missing or awkward today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,18 +1,21 @@
 name: 💡 Enhancement / feature request
-description: Suggest an improvement to this repository — a new or improved skill, client manifest, docs, or registry metadata.
+description: "Suggest an improvement to this repository: a new or improved skill, client manifest, docs, or registry metadata."
 title: "[Enhancement]: "
 labels: ["enhancement", "needs-triage"]
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for the suggestion! 🙏
+        Thanks for the suggestion. We welcome ideas for this repository's contents: skills, client manifests, docs, and registry metadata.
 
-        **This tracker covers the _contents of this repository_.** To request new **tools** or **product capabilities** in the hosted Atlassian Rovo MCP Server, please use the [Atlassian Support Portal](https://support.atlassian.com/) or [Atlassian Community](https://community.atlassian.com/) so it reaches the product team.
+        Two honest notes:
+
+        - This repo isn't actively monitored and has no response-time commitment. If you need a timely answer, the [Atlassian Community](https://community.atlassian.com/) is a faster, managed channel.
+        - To request new tools or product capabilities in the hosted Atlassian Rovo MCP Server, please use [Atlassian Support](https://support.atlassian.com/) or the [Atlassian Community](https://community.atlassian.com/) so it reaches the product team.
   - type: checkboxes
-    id: scope
+    id: dedup
     attributes:
-      label: Confirm scope
+      label: Before you start
       options:
         - label: I searched [existing issues](https://github.com/atlassian/atlassian-mcp-server/issues) and didn't find a duplicate.
           required: true


### PR DESCRIPTION
## What

Adds GitHub issue forms under `.github/ISSUE_TEMPLATE/`:

- `bug_report.yml`: a bug form for this repo's contents (README and docs, client manifests, `server.json`, and skills), with a duplicate-search check, an affected-area dropdown, and fields for repro steps and client version.
- `enhancement.yml`: a feature/enhancement form for new or improved skills, client manifests, docs, and registry metadata.
- `config.yml`: keeps the "New issue" page structured (no blank issues) and lists the support channels people can use if they're stuck.

## Why

We'd like this repo to be a welcoming place for bug reports and ideas about its contents, since that kind of activity is part of what makes a project feel alive. The forms keep reports consistent enough to triage now and to automate later, without acting as a gate.

We also want to be honest about how things stand today: we don't watch this repo full time, so we can't promise a quick reply here. If someone is blocked or needs an answer soon, the forms point them to Atlassian Support and the dedicated Atlassian Rovo MCP Server community forum, both of which are staffed. Security reports go to the private vulnerability channel rather than a public issue.

## Notes

- The forms apply a `needs-triage` label alongside the default `bug` and `enhancement` labels. That label now exists in the repo.
- The community links point to the dedicated Atlassian Rovo MCP Server forum.
- Issue templates only take effect once they merge to the default branch.
- YAML validated locally.

## Possible follow-up (not in this PR)

A later change could add automation on `issues.opened`: auto-label, post a friendly first reply so no issue sits unanswered, and optionally bridge to an internal tracking ticket for follow-up.
