### PR TITLE
chore: tidy repo docs and metadata (SECURITY, CONTRIBUTING, license, issue chooser)

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -9,7 +9,7 @@
   },
   "homepage": "https://confluence.atlassian.com",
   "repository": "https://github.com/atlassian/atlassian-mcp-server",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "keywords": ["atlassian", "mcp", "rovo", "jira", "confluence", "skills"],
   "logo": "assets/logo.svg",
   "skills": "./skills/",

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -13,8 +13,6 @@ contact_links:
   - name: 👩‍💻 Developer and API questions
     url: https://community.developer.atlassian.com/
     about: For Atlassian developer platform and API questions, try the Developer Community.
-  - name: 🔒 Report a security vulnerability
-    url: https://www.atlassian.com/trust/security/report-a-vulnerability
-    about: >-
-      Found a security problem? Report it privately to the Atlassian security
-      team. Please don't open a public issue.
+# Note: GitHub automatically adds a "Report a security vulnerability" entry to
+# this chooser because the repo has a SECURITY.md. We intentionally do not add a
+# second one here to avoid a duplicate.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,18 +1,27 @@
-# Contributing to [atlassian-mcp-server]
+# Contributing to the Atlassian Rovo MCP Server
 
-Thank you for considering a contribution to [atlassian-mcp-server]! Pull requests, issues and comments are welcome. For pull requests, please:
+Thanks for your interest in contributing. Pull requests, issues, and comments are all welcome.
 
-* Add tests for new features and bug fixes
-* Follow the existing style
-* Separate unrelated changes into multiple pull requests
+It helps to know what lives in this repo: the documentation, the client manifests (`.mcp.json` and the Claude, Cursor, and Gemini plugin manifests), the MCP registry entry (`server.json`), and the [skills](skills/). The server itself runs as a hosted service at `mcp.atlassian.com` and isn't part of this repo, so changes here are about those public-facing pieces.
 
-See the existing issues for things to start contributing.
+## Opening an issue
 
-For bigger changes, please make sure you start a discussion first by creating an issue and explaining the intended change.
+Use one of the [issue forms](https://github.com/atlassian/atlassian-mcp-server/issues/new/choose). If your report is really about the hosted server, authentication, or an Atlassian product rather than this repo, the forms will point you to faster support channels.
 
-Atlassian requires contributors to sign a Contributor License Agreement, known as a CLA. This serves as a record stating that the contributor is entitled to contribute the code/documentation/translation to the project and is willing to have it used in distributions and derivative works (or is willing to transfer ownership).
+## Sending a pull request
 
-Prior to accepting your contributions we ask that you please follow the appropriate link below to digitally sign the CLA. The Corporate CLA is for those who are contributing as a member of an organization and the individual CLA is for those contributing as an individual.
+A few things that make review easier:
 
-* [CLA for corporate contributors](https://opensource.atlassian.com/corporate)
-* [CLA for individuals](https://opensource.atlassian.com/individual)
+- Keep each pull request focused on one change. Split unrelated work into separate PRs.
+- Match the existing style and structure of the file you're editing.
+- If you touch a manifest (`.mcp.json`, `server.json`, or a plugin file), check that it's still valid and renders the way you expect.
+- For a larger change, open an issue first so we can talk it through before you put in the work.
+
+## Contributor License Agreement
+
+Atlassian asks contributors to sign a Contributor License Agreement (CLA). It's a record that you have the right to contribute your code, documentation, or other work, and that you're willing to have it used in the project and any derivative works.
+
+Please sign the CLA before we accept your contribution:
+
+- [CLA for corporate contributors](https://opensource.atlassian.com/corporate), if you're contributing on behalf of an organization
+- [CLA for individuals](https://opensource.atlassian.com/individual), if you're contributing on your own

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) [2025] Atlassian US., Inc.
+   Copyright (c) 2026 Atlassian US., Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2026 Atlassian US., Inc.
+   Copyright (c) 2026 Atlassian US, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,1 +1,39 @@
-If you believe you have identified a security issue that aligns with Atlassian’s [definition of a vulnerability](https://www.atlassian.com/trust/security/report-a-vulnerability#definition-of-vulnerability), please submit your report to our security team using any of the methods outlined [here](https://www.atlassian.com/trust/security/report-a-vulnerability).
+# Security policy
+
+Thanks for helping keep the Atlassian Rovo MCP Server and the people who use it safe.
+
+## Reporting a vulnerability
+
+**Please don't open a public GitHub issue for a security problem.** Public issues are visible to everyone and can put users at risk before a fix is ready.
+
+Report it privately to the Atlassian security team instead. If what you found matches Atlassian's [definition of a vulnerability](https://www.atlassian.com/trust/security/report-a-vulnerability#definition-of-vulnerability), submit it through one of the methods on the [Report a vulnerability](https://www.atlassian.com/trust/security/report-a-vulnerability) page. That gets it to the people who can triage and fix it, and eligible reports may qualify for Atlassian's bug bounty program.
+
+A good report usually includes:
+
+- What you found, and why you think it's a security issue
+- Steps to reproduce, or a proof of concept
+- The affected component (a file in this repo, a client manifest, or the hosted endpoint)
+- The impact you think it could have
+
+## What this repository covers
+
+This repo holds the public pieces of the Atlassian Rovo MCP Server: the documentation, the client manifests (`.mcp.json` and the Claude, Cursor, and Gemini plugin manifests), the MCP registry entry (`server.json`), and the [skills](skills/).
+
+The server itself is a hosted service at `mcp.atlassian.com`. Issues in the hosted service, in authentication, or in any Atlassian product go through the same [Report a vulnerability](https://www.atlassian.com/trust/security/report-a-vulnerability) process above. Atlassian maintains and updates the hosted server, so there's nothing for you to patch on your end. Just connect to the current endpoint documented in the [README](README.md).
+
+## Using the MCP server safely
+
+MCP lets an AI agent act in Jira, Confluence, and other products with your permissions. That's useful, and it carries real risk. Language models can be tricked by [prompt injection](https://owasp.org/www-community/attacks/PromptInjection) and [tool poisoning](https://invariantlabs.ai/blog/mcp-security-notification-tool-poisoning-attacks), where hidden instructions push an agent to leak data or make changes you never asked for.
+
+A few habits that lower the risk:
+
+- Connect only to MCP clients and servers you trust.
+- Use least privilege: scoped tokens and the smallest project or space access you need.
+- Ask for human confirmation before any high-impact or destructive action.
+- Watch your audit logs for anything that looks off.
+
+For the wider picture, see [MCP clients: understanding the potential security risks](https://www.atlassian.com/blog/artificial-intelligence/mcp-risk-awareness) and [Atlassian's security practices](https://www.atlassian.com/trust/security/security-practices).
+
+## Coordinated disclosure
+
+Please give the security team a fair chance to investigate and ship a fix before you share details publicly. We're grateful to the researchers who report responsibly and work with us on timing.


### PR DESCRIPTION
## What

A pass over the repo's docs and metadata to fix a few rough edges.

- **SECURITY.md** rewritten from a single sentence into a real policy: how to report a vulnerability privately, what this repo owns versus the hosted server, safe-usage guidance (least privilege, prompt-injection awareness, audit logs), and a note on coordinated disclosure.
- **Issue chooser:** removed the duplicate "Report a security vulnerability" entry. GitHub adds one automatically when a `SECURITY.md` exists, and `config.yml` was adding a second. Left a comment so it isn't re-added.
- **CONTRIBUTING.md:** replaced the unfilled `[atlassian-mcp-server]` template placeholders with the real project name, dropped the "add tests" line (this repo has no test suite; it's docs, manifests, and skills), and pointed contributors at the new issue forms.
- **License metadata:** `.cursor-plugin/plugin.json` declared `MIT`, which contradicts the repo's Apache-2.0 `LICENSE` and the README badge. Corrected to `Apache-2.0`.
- **LICENSE copyright line:** cleaned up the notice. `Copyright (c) [2025] Atlassian US., Inc.` is now `Copyright (c) 2026 Atlassian US, Inc.` (removed the leftover template brackets, bumped the year to 2026, and fixed the stray period after "US").

## Why

These are small inconsistencies that make an official repo look unfinished: a one-line security policy, a contributing guide with placeholder text and instructions that don't apply here, a license field that disagrees with the actual license, and a copyright line still wrapped in its template brackets.

## Not changed

- `CODE_OF_CONDUCT.md` is the Contributor Covenant v1.3.0. It works, but it's an old version and names no specific reporting contact. I left it alone rather than rewrite a standard document. Happy to bump it to Covenant 2.1 with a real contact in a follow-up.
