### PR TITLE
chore: remove SSE remote endpoint from server.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# MCP Registry signing key — retrieved from Keeper only when publishing.
+# Never commit this. See the "Publishing Changes to the MCP Registry" runbook.
+key.pem
+*.pem
+
+# OS / editor noise
+.DS_Store
+Thumbs.db
+*.swp
+
+# Logs
+*.log

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "com.atlassian/atlassian-mcp-server",
   "description": "Connect to Atlassian Jira, Confluence, and Compass to search, create, and manage your work.",
   "title": "Atlassian Rovo MCP Server",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "websiteUrl": "https://support.atlassian.com/atlassian-rovo-mcp-server/docs/getting-started-with-the-atlassian-remote-mcp-server/",
   "repository": {
     "url": "https://github.com/atlassian/atlassian-mcp-server",
@@ -13,10 +13,6 @@
     {
       "type": "streamable-http",
       "url": "https://mcp.atlassian.com/v1/mcp"
-    },
-    {
-      "type": "sse",
-      "url": "https://mcp.atlassian.com/v1/sse"
     },
     {
       "type": "streamable-http",


### PR DESCRIPTION
## What

Removes the deprecated SSE remote (`https://mcp.atlassian.com/v1/sse`) from the MCP Registry server definition in `server.json`, leaving only the two `streamable-http` endpoints.

Bumps `version` `1.1.2` → `1.1.3` as required by the registry publish rule (the registry rejects republishing an existing version).

## Diff summary
- Removed the `{ "type": "sse", ... }` entry from `remotes`.
- Bumped `version`.

## Verification 

<img width="1252" height="872" alt="image" src="https://github.com/user-attachments/assets/94abfabe-5abd-43a3-b3e4-b2c1572f3f73" />
`1.1.3` is published
