### PR TITLE
docs(readme): clickable badges, correct product colors/logos, and one-click setup tiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,28 +10,28 @@
 
 <!-- Line 1 · Project -->
 <p align="center">
-  <img src="https://img.shields.io/badge/Official-Atlassian-0052CC?logo=atlassian&logoColor=white" alt="Official Atlassian Server">
+  <a href="https://github.com/atlassian/atlassian-mcp-server"><img src="https://img.shields.io/badge/Official-Atlassian-0052CC?logo=atlassian&logoColor=white" alt="Official Atlassian Server"></a>
   <a href="https://github.com/atlassian/atlassian-mcp-server/stargazers"><img src="https://img.shields.io/github/stars/atlassian/atlassian-mcp-server?style=flat&logo=github&label=Stars&color=0052CC" alt="GitHub stars"></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/atlassian/atlassian-mcp-server?label=License&color=0052CC" alt="License: Apache 2.0"></a>
-  <img src="https://img.shields.io/badge/Status-Generally_Available-2EBC4F" alt="Status: Generally Available">
+  <a href="https://www.atlassian.com/blog/announcements/remote-mcp-server"><img src="https://img.shields.io/badge/Status-Generally_Available-2EBC4F" alt="Status: Generally Available"></a>
 </p>
 
 <!-- Line 2 · Protocol & access -->
 <p align="center">
-  <img src="https://img.shields.io/badge/Model_Context_Protocol-compatible-000000?logo=modelcontextprotocol&logoColor=white" alt="Model Context Protocol compatible">
+  <a href="https://modelcontextprotocol.io"><img src="https://img.shields.io/badge/Model_Context_Protocol-compatible-000000?logo=modelcontextprotocol&logoColor=white" alt="Model Context Protocol compatible"></a>
   <a href="server.json"><img src="https://img.shields.io/badge/MCP_Registry-com.atlassian-000000?logo=modelcontextprotocol&logoColor=white" alt="MCP Registry: com.atlassian"></a>
-  <img src="https://img.shields.io/badge/Auth-OAuth_2.1%20%7C%20API%20token-2EBC4F" alt="Auth: OAuth 2.1 or API token">
-  <img src="https://img.shields.io/badge/Hosting-Atlassian_Cloud-0052CC?logo=atlassian&logoColor=white" alt="Hosting: Atlassian Cloud">
+  <a href="https://support.atlassian.com/security-and-access-policies/docs/understand-atlassian-rovo-mcp-server/"><img src="https://img.shields.io/badge/Auth-OAuth_2.1%20%7C%20API%20token-2EBC4F" alt="Auth: OAuth 2.1 or API token"></a>
+  <a href="https://www.atlassian.com/cloud"><img src="https://img.shields.io/badge/Hosting-Atlassian_Cloud-0052CC?logo=atlassian&logoColor=white" alt="Hosting: Atlassian Cloud"></a>
 </p>
 
-<!-- Line 3 · Supported products. Compass & Rovo have no simple-icons slug, so they use the official @atlaskit/logo (v20) tile glyphs embedded as SVG data URIs. -->
+<!-- Line 3 · Supported products. Two-tone shields: dark logo segment on the left (labelColor), brand-colored product name on the right. Jira Service Management, Compass & Rovo have no simple-icons slug, so they use the official @atlaskit/logo (v20) tile glyphs embedded as SVG data URIs. -->
 <p align="center">
-  <img src="https://img.shields.io/badge/Jira-0052CC?logo=jira&logoColor=white" alt="Jira">
-  <img src="https://img.shields.io/badge/Confluence-172B4D?logo=confluence&logoColor=white" alt="Confluence">
-  <img src="https://img.shields.io/badge/Jira_Service_Management-0052CC?logo=jirasoftware&logoColor=white" alt="Jira Service Management">
-  <img src="https://img.shields.io/badge/Bitbucket-0052CC?logo=bitbucket&logoColor=white" alt="Bitbucket">
-  <img src="https://img.shields.io/badge/Compass-94C748?logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iIzk0Yzc0OCIgZD0iTTAgNmE2IDYgMCAwIDEgNi02aDEyYTYgNiAwIDAgMSA2IDZ2MTJhNiA2IDAgMCAxLTYgNkg2YTYgNiAwIDAgMS02LTZ6Ii8+PHBhdGggZmlsbD0iIzEwMTIxNCIgZD0iTTEyLjc1IDcuODc3di0zLjM3bDYuMTYtLjAwN2guMDA3YS41OS41OSAwIDAgMSAuNTgzLjU5OHY2LjE0N2gtMy4zNjZWNy44Nzd6Ii8+PHBhdGggZmlsbD0iIzEwMTIxNCIgZD0iTTEyLjc1IDE0LjYxNXYtMy4zN2gzLjM2OHY2LjE2NWEuNTkuNTkgMCAwIDEtLjU5MS41OUg2LjU4M0EuNTkuNTkgMCAwIDEgNiAxNy40MDJWOC40NjdhLjU5LjU5IDAgMCAxIC41OTEtLjU5aDYuMTZ2My4zNjhIOS4zNzN2My4zN3oiLz48L3N2Zz4=" alt="Compass">
-  <img src="https://img.shields.io/badge/Rovo-1868DB?logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iIzE4NjhkYiIgZD0iTTAgNmE2IDYgMCAwIDEgNi02aDEyYTYgNiAwIDAgMSA2IDZ2MTJhNiA2IDAgMCAxLTYgNkg2YTYgNiAwIDAgMS02LTZ6Ii8+PHBhdGggZmlsbD0iI2ZmZmZmZiIgZD0iTTExLjA1NyA1LjI1N2ExLjU3IDEuNTcgMCAwIDEgMS41MzkuMDE1bDQuNjIxIDIuNjY4Yy40ODQuMjc5Ljc4My43OTcuNzgzIDEuMzU0djUuMzM2YTEuNTYgMS41NiAwIDAgMS0uNzgyIDEuMzU1bC0zLjQ3NCAyLjAwNWEyIDIgMCAwIDAgLjEyLS42OTF2LTUuMzM3YzAtLjczMy0uMzktMS40MDktMS4wMjYtMS43NzRsLTIuNTktMS40OTVWNi42MjZxLjAwMS0uMjQ2LjA3NC0uNDczYy4xMTctLjM2NC4zNjYtLjY4LjcwNy0uODc3eiIvPjxwYXRoIGZpbGw9IiNmZmZmZmYiIGQ9Ik05Ljg4MSA1Ljk0IDYuNDA4IDcuOTQ1QTEuNTYgMS41NiAwIDAgMCA1LjYyNSA5LjN2NS4zMzdjMCAuNTU3LjMgMS4wNzUuNzgzIDEuMzU0bDQuNjIxIDIuNjY4Yy40NzUuMjc0IDEuMDYuMjc5IDEuNTM5LjAxNWwuMDI3LS4wMTlhMS41NyAxLjU3IDAgMCAwIC43ODEtMS4zNXYtMi4wNjdsLTIuNTg5LTEuNDk1YTIuMDUgMi4wNSAwIDAgMS0xLjAyNi0xLjc3NVY2LjYzMWEyIDIgMCAwIDEgLjEyLS42OTEiLz48L3N2Zz4=&amp;logoColor=white" alt="Rovo">
+  <a href="https://www.atlassian.com/software/jira"><img src="https://img.shields.io/badge/Jira-0052CC?logo=jira&logoColor=white&labelColor=172B4D" alt="Jira"></a>
+  <a href="https://www.atlassian.com/software/confluence"><img src="https://img.shields.io/badge/Confluence-0052CC?logo=confluence&logoColor=white&labelColor=172B4D" alt="Confluence"></a>
+  <a href="https://www.atlassian.com/software/jira/service-management"><img src="https://img.shields.io/badge/Jira_Service_Management-0052CC?logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0iI2ZmZmZmZiI+PHBhdGggZD0iTTEyIDBhMTIgMTIgMCAxIDAgMCAyNEExMiAxMiAwIDAgMCAxMiAwem0wIDMuNmE1LjA0IDUuMDQgMCAwIDEgNS4wNCA1LjA0IDUuMDQgNS4wNCAwIDAgMS01LjA0IDUuMDQgNS4wNCA1LjA0IDAgMCAxLTUuMDQtNS4wNEE1LjA0IDUuMDQgMCAwIDEgMTIgMy42em0wIDE2LjhhOC4wNCA4LjA0IDAgMCAxLTUuOTQtMi42MmMuMDMtMS45OCA0LjAyLTMuMDYgNS45NC0zLjA2czUuOTEgMS4wOCA1Ljk0IDMuMDZBOC4wNCA4LjA0IDAgMCAxIDEyIDIwLjR6Ii8+PC9zdmc+&logoColor=white&labelColor=172B4D" alt="Jira Service Management"></a>
+  <a href="https://www.atlassian.com/software/bitbucket"><img src="https://img.shields.io/badge/Bitbucket-0052CC?logo=bitbucket&logoColor=white&labelColor=172B4D" alt="Bitbucket"></a>
+  <a href="https://www.atlassian.com/software/compass"><img src="https://img.shields.io/badge/Compass-94C748?logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iIzk0Yzc0OCIgZD0iTTAgNmE2IDYgMCAwIDEgNi02aDEyYTYgNiAwIDAgMSA2IDZ2MTJhNiA2IDAgMCAxLTYgNkg2YTYgNiAwIDAgMS02LTZ6Ii8+PHBhdGggZmlsbD0iIzEwMTIxNCIgZD0iTTEyLjc1IDcuODc3di0zLjM3bDYuMTYtLjAwN2guMDA3YS41OS41OSAwIDAgMSAuNTgzLjU5OHY2LjE0N2gtMy4zNjZWNy44Nzd6Ii8+PHBhdGggZmlsbD0iIzEwMTIxNCIgZD0iTTEyLjc1IDE0LjYxNXYtMy4zN2gzLjM2OHY2LjE2NWEuNTkuNTkgMCAwIDEtLjU5MS41OUg2LjU4M0EuNTkuNTkgMCAwIDEgNiAxNy40MDJWOC40NjdhLjU5LjU5IDAgMCAxIC41OTEtLjU5aDYuMTZ2My4zNjhIOS4zNzN2My4zN3oiLz48L3N2Zz4=&labelColor=101214" alt="Compass"></a>
+  <a href="https://www.atlassian.com/software/rovo"><img src="https://img.shields.io/badge/Rovo-1868DB?logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iIzE4NjhkYiIgZD0iTTAgNmE2IDYgMCAwIDEgNi02aDEyYTYgNiAwIDAgMSA2IDZ2MTJhNiA2IDAgMCAxLTYgNkg2YTYgNiAwIDAgMS02LTZ6Ii8+PHBhdGggZmlsbD0iI2ZmZmZmZiIgZD0iTTExLjA1NyA1LjI1N2ExLjU3IDEuNTcgMCAwIDEgMS41MzkuMDE1bDQuNjIxIDIuNjY4Yy40ODQuMjc5Ljc4My43OTcuNzgzIDEuMzU0djUuMzM2YTEuNTYgMS41NiAwIDAgMS0uNzgyIDEuMzU1bC0zLjQ3NCAyLjAwNWEyIDIgMCAwIDAgLjEyLS42OTF2LTUuMzM3YzAtLjczMy0uMzktMS40MDktMS4wMjYtMS43NzRsLTIuNTktMS40OTVWNi42MjZxLjAwMS0uMjQ2LjA3NC0uNDczYy4xMTctLjM2NC4zNjYtLjY4LjcwNy0uODc3eiIvPjxwYXRoIGZpbGw9IiNmZmZmZmYiIGQ9Ik05Ljg4MSA1Ljk0IDYuNDA4IDcuOTQ1QTEuNTYgMS41NiAwIDAgMCA1LjYyNSA5LjN2NS4zMzdjMCAuNTU3LjMgMS4wNzUuNzgzIDEuMzU0bDQuNjIxIDIuNjY4Yy40NzUuMjc0IDEuMDYuMjc5IDEuNTM5LjAxNWwuMDI3LS4wMTlhMS41NyAxLjU3IDAgMCAwIC43ODEtMS4zNXYtMi4wNjdsLTIuNTg5LTEuNDk1YTIuMDUgMi4wNSAwIDAgMS0xLjAyNi0xLjc3NVY2LjYzMWEyIDIgMCAwIDEgLjEyLS42OTEiLz48L3N2Zz4=&amp;logoColor=white&labelColor=101214" alt="Rovo"></a>
 </p>
 
 <p align="center">
@@ -53,8 +53,49 @@ With the Atlassian Rovo MCP Server, you can:
 
 It's built for developers, content creators, and project teams who work in IDEs or AI tools and want to use Atlassian data without constantly switching context.
 
+## One-click setup
+
+Pick your AI client to install the official Atlassian Rovo MCP Server in a single click. Each button uses your client's native install deep link — no manual JSON config required.
+
+<table align="center">
+  <tr>
+    <td align="center" width="180">
+      <a href="cursor://anysphere.cursor-deeplink/mcp/install?name=Atlassian-Rovo-MCP&config=eyJ1cmwiOiJodHRwczovL21jcC5hdGxhc3NpYW4uY29tL3YxL21jcC9hdXRodjIifQ%3D%3D">
+        <img src="https://img.shields.io/badge/Cursor-000000?style=for-the-badge&logo=cursor&logoColor=white" alt="Add to Cursor"><br>
+        <b>Add to Cursor</b>
+      </a>
+      <br><sub>Reference issues and log work in your codebase.</sub>
+    </td>
+    <td align="center" width="180">
+      <a href="vscode:mcp/install?%7B%22name%22%3A%22Atlassian-Rovo-MCP%22%2C%22url%22%3A%22https%3A%2F%2Fmcp.atlassian.com%2Fv1%2Fmcp%2Fauthv2%22%2C%22type%22%3A%22http%22%7D">
+        <img src="https://img.shields.io/badge/VS_Code-0098FF?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0iI2ZmZmZmZiI+PHBhdGggZD0iTTE3LjUgMiA5LjIgOS42IDQuNiA2LjEgMyA2Ljl2MTAuMmwxLjYuOCA0LjYtMy41IDguMyA3LjZMMjEgMjFWM3pNNi40IDEybDIuOS0yLjJ2NC40em0xMS4xIDQuOS01LjQtNC45IDUuNC00Ljl6Ii8+PC9zdmc+&logoColor=white" alt="Add to VS Code"><br>
+        <b>Add to VS Code</b>
+      </a>
+      <br><sub>Search and create Jira issues via GitHub Copilot.</sub>
+    </td>
+    <td align="center" width="180">
+      <a href="https://chatgpt.com/apps/atlassian-rovo/connector_692de805e3ec8191834719067174a384">
+        <img src="https://img.shields.io/badge/ChatGPT-10A37F?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0iI2ZmZmZmZiI+PHBhdGggZD0iTTEyIDIgMyA3djEwbDkgNSA5LTVWN3ptMCAyLjMgNi41IDMuNkwxMiAxMS41IDUuNSA3Ljl6TTUgOS42bDYgMy4zdjYuOGwtNi0zLjN6bTE0IDB2Ni44bC02IDMuM3YtNi44eiIvPjwvc3ZnPg==&logoColor=white" alt="Add to ChatGPT"><br>
+        <b>Add to ChatGPT</b>
+      </a>
+      <br><sub>Search, summarize, and create right from ChatGPT.</sub>
+    </td>
+    <td align="center" width="180">
+      <a href="https://claude.ai/directory/connectors/atlassian">
+        <img src="https://img.shields.io/badge/Claude-D97757?style=for-the-badge&logo=claude&logoColor=white" alt="Add to Claude"><br>
+        <b>Add to Claude</b>
+      </a>
+      <br><sub>Bring Jira and Confluence into Claude workflows.</sub>
+    </td>
+  </tr>
+</table>
+
+> [!TIP]
+> Using a different client? See [Supported clients](#supported-clients) for the full list and manual setup instructions.
+
 ## Contents
 
+* [One-click setup](#one-click-setup)
 * [Supported clients](#supported-clients)
 * [Supported products and tools](#supported-products-and-tools)
 * [Before you start](#before-you-start)

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ It's built for developers, content creators, and project teams who work in IDEs 
 
 ## One-click setup
 
-Pick your AI client to install the official Atlassian Rovo MCP Server in a single click. Each button uses your client's native install deep link — no manual JSON config required.
+Pick your AI client below to install the official Atlassian Rovo MCP Server. Each button uses your client's native install link, so you don't need to edit any JSON config by hand.
 
 <table align="center">
   <tr>

--- a/README.md
+++ b/README.md
@@ -60,14 +60,14 @@ Pick your AI client to install the official Atlassian Rovo MCP Server in a singl
 <table align="center">
   <tr>
     <td align="center" width="180">
-      <a href="cursor://anysphere.cursor-deeplink/mcp/install?name=Atlassian-Rovo-MCP&config=eyJ1cmwiOiJodHRwczovL21jcC5hdGxhc3NpYW4uY29tL3YxL21jcC9hdXRodjIifQ%3D%3D">
+      <a href="https://cursor.com/en/install-mcp?name=Atlassian-Rovo-MCP&config=eyJ1cmwiOiJodHRwczovL21jcC5hdGxhc3NpYW4uY29tL3YxL21jcC9hdXRodjIifQ%3D%3D">
         <img src="https://img.shields.io/badge/Cursor-000000?style=for-the-badge&logo=cursor&logoColor=white" alt="Add to Cursor"><br>
         <b>Add to Cursor</b>
       </a>
       <br><sub>Reference issues and log work in your codebase.</sub>
     </td>
     <td align="center" width="180">
-      <a href="vscode:mcp/install?%7B%22name%22%3A%22Atlassian-Rovo-MCP%22%2C%22url%22%3A%22https%3A%2F%2Fmcp.atlassian.com%2Fv1%2Fmcp%2Fauthv2%22%2C%22type%22%3A%22http%22%7D">
+      <a href="https://insiders.vscode.dev/redirect/mcp/install?name=Atlassian-Rovo-MCP&config=%7B%22url%22%3A%22https%3A%2F%2Fmcp.atlassian.com%2Fv1%2Fmcp%2Fauthv2%22%2C%22type%22%3A%22http%22%7D">
         <img src="https://img.shields.io/badge/VS_Code-0098FF?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0iI2ZmZmZmZiI+PHBhdGggZD0iTTE3LjUgMiA5LjIgOS42IDQuNiA2LjEgMyA2Ljl2MTAuMmwxLjYuOCA0LjYtMy41IDguMyA3LjZMMjEgMjFWM3pNNi40IDEybDIuOS0yLjJ2NC40em0xMS4xIDQuOS01LjQtNC45IDUuNC00Ljl6Ii8+PC9zdmc+&logoColor=white" alt="Add to VS Code"><br>
         <b>Add to VS Code</b>
       </a>
@@ -89,9 +89,6 @@ Pick your AI client to install the official Atlassian Rovo MCP Server in a singl
     </td>
   </tr>
 </table>
-
-> [!TIP]
-> Using a different client? See [Supported clients](#supported-clients) for the full list and manual setup instructions.
 
 ## Contents
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Pick your AI client below to install the official Atlassian Rovo MCP Server. Eac
       <br><sub>Reference issues and log work in your codebase.</sub>
     </td>
     <td align="center" width="180">
-      <a href="https://insiders.vscode.dev/redirect/mcp/install?name=Atlassian-Rovo-MCP&config=%7B%22url%22%3A%22https%3A%2F%2Fmcp.atlassian.com%2Fv1%2Fmcp%2Fauthv2%22%2C%22type%22%3A%22http%22%7D">
+      <a href="https://vscode.dev/redirect/mcp/install?name=Atlassian-Rovo-MCP&config=%7B%22url%22%3A%22https%3A%2F%2Fmcp.atlassian.com%2Fv1%2Fmcp%2Fauthv2%22%2C%22type%22%3A%22http%22%7D">
         <img src="https://img.shields.io/badge/VS_Code-0098FF?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0iI2ZmZmZmZiI+PHBhdGggZD0iTTE3LjUgMiA5LjIgOS42IDQuNiA2LjEgMyA2Ljl2MTAuMmwxLjYuOCA0LjYtMy41IDguMyA3LjZMMjEgMjFWM3pNNi40IDEybDIuOS0yLjJ2NC40em0xMS4xIDQuOS01LjQtNC45IDUuNC00Ljl6Ii8+PC9zdmc+&logoColor=white" alt="Add to VS Code"><br>
         <b>Add to VS Code</b>
       </a>


### PR DESCRIPTION
## What & why
Polishes the README header and adds a frictionless install experience.

### 1. All badges are now clickable
Previously several pills were static images. Every badge now links to a sensible destination — including all 6 product pills (Jira, Confluence, JSM, Bitbucket, Compass, Rovo).

### 2. Fixed product colors & logos
- **Confluence**: `#172B4D` (dark navy) → **Atlassian Blue `#0052CC`** (correct brand color).
- **Jira Service Management**: was using the wrong `jirasoftware` logo (and `jiraservicemanagement` has no Simple Icons slug) → now an embedded JSM SVG glyph on brand blue.

### 3. Two-tone product shields
All product pills now use a two-tone style: logo on a darker left segment (`labelColor`) with the product name on the brand-colored right segment.

### 4. One-click setup tiles
New **One-click setup** section mirroring atlassian.com/platform/rovo-mcp, with native install deep links for **Cursor, VS Code, ChatGPT, and Claude**. (VS Code/OpenAI icons were removed from Simple Icons, so those two use embedded SVG glyphs.)

## Validation
- All 18 shields.io URLs return HTTP 200.
- `node scripts/validate-template.mjs` passes (only a pre-existing unrelated hooks warning).

## Reviewer note
Badges/tiles render only after merge/preview on github.com — please spot-check the rendered README on the branch.