### PR TITLE
Add MCP to plugin display names

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,6 +9,7 @@
   "plugins": [
     {
       "name": "atlassian",
+      "displayName": "Atlassian MCP",
       "description": "Connect to Atlassian products including Jira and Confluence. Search and create issues, access documentation, manage sprints, and integrate your development workflow with Atlassian's collaboration tools.",
       "version": "1.0.0",
       "author": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "atlassian",
+  "displayName": "Atlassian MCP",
   "description": "Connect to Atlassian products including Jira and Confluence. Search and create issues, access documentation, manage sprints, and integrate your development workflow with Atlassian's collaboration tools.",
   "author": {
     "name": "Atlassian"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atlassian",
-  "displayName": "Atlassian",
+  "displayName": "Atlassian MCP",
   "description": "Atlassian plugin for Cursor with MCP and skills for Jira, Confluence, triage, backlogs, status reports, and more.",
   "version": "0.1.0",
   "author": {


### PR DESCRIPTION
## Summary

Updates the human-facing Claude Code and Cursor plugin listing names to **Atlassian MCP**.

The stable `atlassian` identifiers remain unchanged, preserving existing install commands and configuration references. `server.json` is intentionally unchanged because its title already includes MCP.

## Why

The marketplace listings currently display as "Atlassian", which omits the MCP designation used for the product.

## Validation

- Parsed all changed JSON manifests with `jq empty`
- Ran `git diff --check`
- The repository validator (`node scripts/validate-template.mjs`) could not run because Node.js is unavailable in this checkout.
