### PR TITLE
use mcpServers in Cursor plugin manifest

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -13,5 +13,5 @@
   "keywords": ["atlassian", "mcp", "rovo", "jira", "confluence", "skills"],
   "logo": "assets/logo.svg",
   "skills": "./skills/",
-  "mcp": "./.mcp.json"
+  "mcpServers": "./.mcp.json"
 }

--- a/scripts/validation/client-formats.mjs
+++ b/scripts/validation/client-formats.mjs
@@ -107,6 +107,10 @@ async function validateOnePlugin(validation, pluginDir, pluginName) {
     );
   }
 
+  if (typeof pluginManifest.mcpServers !== "string") {
+    addError(validation, `${pluginName}: Cursor plugin.json.mcpServers must be a relative path string.`);
+  }
+
   const manifestFields = ["logo", "rules", "skills", "agents", "commands", "hooks", "mcp", "mcpServers"];
   for (const field of manifestFields) {
     const values = extractPathValues(pluginManifest[field]);


### PR DESCRIPTION
## Summary

I noticed this in Cursor Customize. The marketplace Atlassian plugin had Local MCP working, but the Cloud environment row was missing entirely (not greyed out). Google Calendar on the same machine showed both Local and Cloud.

Installed copy was marketplace `0.1.0` at `19f71578`. `.cursor-plugin/plugin.json` used `"mcp": "./.mcp.json"`. Cursor's schema has no `mcp` field. The documented field is `mcpServers`: https://cursor.com/docs/reference/plugins#mcp-servers

Claude's plugin in this repo already uses `mcpServers`. `.mcp.json` is already HTTP `https://mcp.atlassian.com/v1/mcp/authv2`, same shape as Calendar. Only the Cursor manifest key was wrong.

Patching the on-disk plugin cache locally did not make Cloud appear. Cursor fills the Cloud row from its cloud catalog, not that cache. This is the publishable fix, but **TBC whether marketplace republish actually shows Cloud**.

Validator now requires Cursor `plugin.json.mcpServers` to be a relative path string, same as Claude. Path existence is the existing referenced-path check. Covered by `the repository package passes validation`.

## Test plan
- [ ] `npm test`
- [ ] After Cursor marketplace review, Customize → Atlassian shows Cloud next to Local (TBC)
- [ ] New Cloud Agent can use Atlassian tools after OAuth
- [ ] Local Atlassian MCP still works