### PR TITLE
Point Cursor and Claude Code plugins at the v2 endpoint

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "atlassian": {
       "type": "http",
-      "url": "https://mcp.atlassian.com/v1/mcp/authv2"
+      "url": "https://mcp.atlassian.com/v2/mcp"
     }
   }
 }

--- a/mcp.json
+++ b/mcp.json
@@ -3,7 +3,7 @@
   "mcpServers": {
     "atlassian": {
       "type": "streamable-http",
-      "url": "https://mcp.atlassian.com/v1/mcp/authv2"
+      "url": "https://mcp.atlassian.com/v2/mcp"
     }
   }
 }


### PR DESCRIPTION
## Summary

The README now recommends `https://mcp.atlassian.com/v2/mcp`, but the Cursor and Claude Code plugins both resolve their server config from `.mcp.json`, which still installed v1. Anyone installing either plugin got v1 while the docs promised v2. This closes that gap.

- `.mcp.json` — shared by `.cursor-plugin/plugin.json` and `.claude-plugin/plugin.json`, so this single line migrates both plugins.
- `mcp.json` — changes alongside it because `scripts/validation/repository.mjs` requires the Agent Plugins and native MCP endpoints to match. Side effect worth noting: this also moves Kiro and other Agent Plugins clients to v2.

v2 unifies OAuth and API-token auth behind one endpoint, so the previous `/v1/mcp/authv2` variant has no suffix to carry forward. Transport `type` fields are unchanged (`http` for the native config, `streamable-http` for Agent Plugins).

VS Code needed no change here — it has no manifest in this repo, and its README install button was already migrated in #228.

## Not included

`gemini-extension.json` (still `/v1/mcp`) and `server.json` (two v1 remotes, publishes to the public MCP Registry) remain on v1. Neither is covered by endpoint validation, so they can drift silently. Flagging for a follow-up owner rather than absorbing them here, since the registry entry likely has its own release process.

## Test plan

- [x] `npm run validate` passes
- [x] `npm test` passes (17/17)
- [ ] Install the Cursor plugin from a branch build and confirm it connects to v2
- [ ] `claude mcp` / plugin install and confirm the v2 endpoint resolves and authenticates

Made with [Cursor](https://cursor.com)