### PR TITLE
Point the Gemini CLI extension at the v2 endpoint

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "mcpServers": {
     "atlassian-rovo-mcp-server": {
-      "url": "https://mcp.atlassian.com/v1/mcp"
+      "url": "https://mcp.atlassian.com/v2/mcp"
     }
   }
 }


### PR DESCRIPTION
Moving Gemini CLI config to point to new v2/mcp