### PR TITLE
(chore) Update MCP Registry entry to include v2/mcp endpoint

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,15 +1,19 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "com.atlassian/atlassian-mcp-server",
-  "description": "Connect to Atlassian Jira, Confluence, and Compass to search, create, and manage your work.",
+  "description": "Connect to Atlassian Jira, Confluence, Loom, and more to search, create, and manage your work.",
   "title": "Atlassian Rovo MCP Server",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "websiteUrl": "https://support.atlassian.com/atlassian-rovo-mcp-server/docs/getting-started-with-the-atlassian-remote-mcp-server/",
   "repository": {
     "url": "https://github.com/atlassian/atlassian-mcp-server",
     "source": "github"
   },
   "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.atlassian.com/v2/mcp"
+    },
     {
       "type": "streamable-http",
       "url": "https://mcp.atlassian.com/v1/mcp"


### PR DESCRIPTION
Changes:
- added `https://mcp.atlassian.com/v2/mcp` 
- updated server description